### PR TITLE
Lockdown host admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
     unless current_user.admin?
       redirect_to root_path
     end
+    current_user.admin?
   end
 
   def force_to_current_user

--- a/app/controllers/event_hosts_controller.rb
+++ b/app/controllers/event_hosts_controller.rb
@@ -26,6 +26,7 @@ class EventHostsController < ApplicationController
   # POST /event_hosts
   # POST /event_hosts.json
   def create
+    return unless restrict_to_admin
     @event_host = @event.event_hosts.new(event_host_params)
 
     respond_to do |format|
@@ -42,6 +43,7 @@ class EventHostsController < ApplicationController
   # PATCH/PUT /event_hosts/1
   # PATCH/PUT /event_hosts/1.json
   def update
+    return unless restrict_to_admin
     respond_to do |format|
       if @event_host.update(event_host_params)
         format.html {redirect_to [@event, @event_host], notice: 'Event host was successfully updated.'}
@@ -56,6 +58,7 @@ class EventHostsController < ApplicationController
   # DELETE /event_hosts/1
   # DELETE /event_hosts/1.json
   def destroy
+    return unless restrict_to_admin
     # Better is to set the date to be yesterday?
     @event_host.end_date = Date.yesterday
     @event_host.save

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -26,6 +26,7 @@ class EventsController < ApplicationController
     unless current_user.admin?
       redirect_to events_path
     end
+    current_user.admin?
   end
 
   def get_my_events
@@ -45,7 +46,6 @@ class EventsController < ApplicationController
       @my_events.push user_event.event
     end
   end
-
 
 
   def gms_by_scenario
@@ -80,20 +80,21 @@ class EventsController < ApplicationController
 
   # GET /events/new
   def new
-    prevent_non_admin
+    return unless prevent_non_admin
+
     @event      = Event.new
     @user_event = UserEvent.new
   end
 
   # GET /events/1/edit
   def edit
-    prevent_non_admin
+    return unless prevent_non_admin
   end
 
   # POST /events
   # POST /events.json
   def create
-    prevent_non_admin
+    return unless prevent_non_admin
     @event = Event.new(event_params)
 
     respond_to do |format|
@@ -110,7 +111,7 @@ class EventsController < ApplicationController
   # PATCH/PUT /events/1
   # PATCH/PUT /events/1.json
   def update
-    prevent_non_admin
+    return unless prevent_non_admin
     respond_to do |format|
       if @event.update(event_params)
         format.html {redirect_to @event, notice: 'Event was successfully updated.'}
@@ -125,14 +126,13 @@ class EventsController < ApplicationController
   # DELETE /events/1
   # DELETE /events/1.json
   def destroy
-    prevent_non_admin
+    return unless prevent_non_admin
     @event.destroy
     respond_to do |format|
       format.html {redirect_to events_url, notice: 'Event was successfully destroyed.'}
       format.json {head :no_content}
     end
   end
-
 
 
   private


### PR DESCRIPTION
Only admins should be able to modify/create/delete on event hosts. 
This adds the code to prevent the `create`, `update`, and `delete`