### PR TITLE
Open access event page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -41,7 +41,7 @@ class EventsController < ApplicationController
     @my_registrations = []
     @my_events        = []
 
-    unless current_user.nil?
+    if user_signed_in?
       user_events = UserEvent.where(user_id: current_user.id, event_id: current_events)
       user_events.each do |user_event|
         @my_registrations.push user_event
@@ -59,7 +59,7 @@ class EventsController < ApplicationController
   # GET /events/1
   # GET /events/1.json
   def show
-    unless current_user.nil?
+    if user_signed_in?
       @registration = @event.user_events.where(user_id: current_user.id).first
       if @registration
         @sessions        = []

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,4 @@
 class EventsController < ApplicationController
-  # skips authentication only for "index" and "show"
   skip_before_action :authenticate_user!, only: %i[index show]
 
   before_action :set_event, only: [:show, :edit, :update, :destroy, :gms_by_scenario]

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,7 @@
 class EventsController < ApplicationController
+  # skips authentication only for "index" and "show"
+  skip_before_action :authenticate_user!, only: %i[index show]
+
   before_action :set_event, only: [:show, :edit, :update, :destroy, :gms_by_scenario]
   before_action :restrict_to_admin, except: [:show, :index]
   before_action :get_events, :get_my_events
@@ -39,13 +42,14 @@ class EventsController < ApplicationController
     @my_registrations = []
     @my_events        = []
 
-    user_events = UserEvent.where(user_id: current_user.id, event_id: current_events)
-    user_events.each do |user_event|
-      @my_registrations.push user_event
-      @my_events.push user_event.event
+    unless current_user.nil?
+      user_events = UserEvent.where(user_id: current_user.id, event_id: current_events)
+      user_events.each do |user_event|
+        @my_registrations.push user_event
+        @my_events.push user_event.event
+      end
     end
   end
-
 
 
   def gms_by_scenario
@@ -56,24 +60,26 @@ class EventsController < ApplicationController
   # GET /events/1
   # GET /events/1.json
   def show
-    @registration = @event.user_events.where(user_id: current_user.id).first
-    if @registration
-      @sessions        = []
-      @tables          = []
-      @gm_tables       = []
-      @gm_sessions     = []
-      @reg_tables      = @registration.registration_tables
-      @reg_tables_hash = {}
+    unless current_user.nil?
+      @registration = @event.user_events.where(user_id: current_user.id).first
+      if @registration
+        @sessions        = []
+        @tables          = []
+        @gm_tables       = []
+        @gm_sessions     = []
+        @reg_tables      = @registration.registration_tables
+        @reg_tables_hash = {}
 
-      @reg_tables.each do |reg_table|
-        @tables << reg_table.table
-        @sessions << reg_table.table.session
-        @reg_tables_hash[reg_table.table] = reg_table
-      end
-      @game_masters = @registration.game_masters
-      @game_masters.each do |gm|
-        @gm_tables << gm.table
-        @gm_sessions << gm.table.session
+        @reg_tables.each do |reg_table|
+          @tables << reg_table.table
+          @sessions << reg_table.table.session
+          @reg_tables_hash[reg_table.table] = reg_table
+        end
+        @game_masters = @registration.game_masters
+        @game_masters.each do |gm|
+          @gm_tables << gm.table
+          @gm_sessions << gm.table.session
+        end
       end
     end
   end
@@ -132,7 +138,6 @@ class EventsController < ApplicationController
       format.json {head :no_content}
     end
   end
-
 
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,6 @@ class EventsController < ApplicationController
   # GET /events
   # GET /events.json
   def index
-    # get_events
   end
 
   def get_events

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,14 +3,11 @@ class WelcomeController < ApplicationController
 
 
   def index
-    unless current_user.nil?
-      if current_user.admin?
-        redirect_to admin_index_path
-        return
-      else
-        redirect_to events_path
-        return
-      end
-    end # current user not nil
+    admin = !current_user.nil? && current_user.admin?
+    if admin
+          redirect_to admin_index_path
+    else
+          redirect_to events_path
+    end
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,8 +3,7 @@ class WelcomeController < ApplicationController
 
 
   def index
-    admin = !current_user.nil? && current_user.admin?
-    if admin
+    if user_signed_in? && current_user.admin?
           redirect_to admin_index_path
     else
           redirect_to events_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def admin?
-    !current_user.nil? and current_user.admin?
+    user_signed_in? and current_user.admin?
   end
 
   def yes_no (value)

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,7 +8,7 @@
       attend.
       <br/><br/>
       This is done by clicking the <span class="btn btn-warning">Register</span> button next to the event on the events
-      listing.
+      listing<% unless user_signed_in? %>, once you have <%= link_to 'Logged in', new_user_session_path, :class => 'btn btn-info' %><% end %>.
     </div>
   </div>
 </div>
@@ -24,33 +24,37 @@
     <div class="col-md-2">&nbsp;</div>
   </li>
   <% @events.each do |event| %>
-      <li class="row list-group-item">
-        <div class="col-md-2"><%= link_to "#{event.name}", event, :class => 'btn btn-sm btn-info' %></div>
-        <div class="col-md-4">
-          <small><%= event.start.to_formatted_s(:long) %> - <%= event.end.to_formatted_s(:long) %></small>
-        </div>
-        <div class="col-md-2"><%= event.location %></div>
-        <div class="col-md-1">
-          <% if !event.external_url.blank? %>
-              <span class="glyphicon glyphicon-duplicate"></span>
-          <% end %>
-        </div>
-        <div class="col-md-1">
-          <% if @my_events.include? event %>
-              <%= link_to "Attending", event, :class => 'btn btn-sm btn-primary' %>
-          <% else %>
-              <% unless event.closed? %>
-                  <%= link_to "Register", new_event_user_event_path(event), :class => 'btn  btn-sm  btn-warning' %>
-              <% end %>
-          <% end %>
-        </div>
-        <% if current_user.admin? %>
-            <div class="col-md-2">
-              <%= link_to 'Edit', edit_event_path(event), :class => 'btn btn-sm  btn-primary' %>
-              <%= link_to 'Destroy', event, method: :delete, data: {confirm: 'Are you sure?'}, :class => 'btn btn-sm btn-danger' %>
-            </div>
+    <li class="row list-group-item">
+      <div class="col-md-2"><%= link_to "#{event.name}", event, :class => 'btn btn-sm btn-info' %></div>
+      <div class="col-md-4">
+        <small><%= event.start.to_formatted_s(:long) %> - <%= event.end.to_formatted_s(:long) %></small>
+      </div>
+      <div class="col-md-2"><%= event.location %></div>
+      <div class="col-md-1">
+        <% if !event.external_url.blank? %>
+          <span class="glyphicon glyphicon-duplicate"></span>
         <% end %>
-      </li>
+      </div>
+      <div class="col-md-1">
+        <% if @my_events.include? event %>
+          <%= link_to "Attending", event, :class => 'btn btn-sm btn-primary' %>
+        <% else %>
+          <% if user_signed_in? %>
+            <% unless event.closed? %>
+              <%= link_to "Register", new_event_user_event_path(event), :class => 'btn  btn-sm  btn-warning' %>
+            <% end %>
+          <% else %>
+            <%= link_to 'Login to register!', new_user_session_path, :class => 'btn btn-info' %>
+          <% end %>
+        <% end %>
+      </div>
+      <% if admin? %>
+        <div class="col-md-2">
+          <%= link_to 'Edit', edit_event_path(event), :class => 'btn btn-sm  btn-primary' %>
+          <%= link_to 'Destroy', event, method: :delete, data: {confirm: 'Are you sure?'}, :class => 'btn btn-sm btn-danger' %>
+        </div>
+      <% end %>
+    </li>
   <% end %>
 </ul>
 <hr>
@@ -61,51 +65,51 @@
 </div>
 <div class="panel-group" id="accordian">
   <% @my_registrations.each do |registration| %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <div class="row">
-            <div class="col-sm-4">
-              <a data-toggle="collapse" data-parent="#accordian" href="#collapse<%= registration.event_id %>"><%= registration.event.name %> <%= registration.event.start.to_formatted_s(:short) %>
-                to <%= registration.event.end.to_formatted_s(:short) %></a>
-            </div>
-            <div class="col-sm-2">
-              <%= button_to "Manage RSVP", event_user_event_path(registration.event, registration), method: :get, :class => 'btn btn-primary' %>
-            </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="row">
+          <div class="col-sm-4">
+            <a data-toggle="collapse" data-parent="#accordian" href="#collapse<%= registration.event_id %>"><%= registration.event.name %> <%= registration.event.start.to_formatted_s(:short) %>
+              to <%= registration.event.end.to_formatted_s(:short) %></a>
           </div>
-
+          <div class="col-sm-2">
+            <%= button_to "Manage RSVP", event_user_event_path(registration.event, registration), method: :get, :class => 'btn btn-primary' %>
+          </div>
         </div>
-        <% # Add in their tables %>
-        <div id="collapse<%= registration.event_id %>" class="panel-collapse collapse">
-          <% if registration.registration_tables.nil? or registration.registration_tables.empty? %>
-              <div class="bg-warning">You are not yet registered for any tables.</div>
-          <% else %>
-              <ul class="list-group">
-                <li class="list-group-item list-group-item-heading">Player Tables</li>
-                <% sorted = registration.registration_tables.sort {|a, b| a.start <=> b.start} %>
-                <% sorted.each do |reg_table| %>
-                    <li class="row list-group-item"><%= reg_table.table.session.name %>
-                      : <%= link_to "#{reg_table.table.scenario.long_name}", reg_table.table.scenario %></li>
-                <% end %>
-              </ul>
-          <% end %>
-          <% if registration.gamemaster? %>
-              <ul class="list-group">
-                <li class="list-group-item list-group-item-heading">Game Master Tables</li>
 
-                <% registration.game_masters.sort.each do |gm| %>
-                    <li class="row list-group-item"><%= gm.table.session.name %>
-                      : <%= link_to "#{gm.table.scenario.long_name}", gm.table.scenario %></li>
-                <% end %>
-              </ul>
-          <% end %>
-        </div>
       </div>
+      <% # Add in their tables %>
+      <div id="collapse<%= registration.event_id %>" class="panel-collapse collapse">
+        <% if registration.registration_tables.nil? or registration.registration_tables.empty? %>
+          <div class="bg-warning">You are not yet registered for any tables.</div>
+        <% else %>
+          <ul class="list-group">
+            <li class="list-group-item list-group-item-heading">Player Tables</li>
+            <% sorted = registration.registration_tables.sort {|a, b| a.start <=> b.start} %>
+            <% sorted.each do |reg_table| %>
+              <li class="row list-group-item"><%= reg_table.table.session.name %>
+                : <%= link_to "#{reg_table.table.scenario.long_name}", reg_table.table.scenario %></li>
+            <% end %>
+          </ul>
+        <% end %>
+        <% if registration.gamemaster? %>
+          <ul class="list-group">
+            <li class="list-group-item list-group-item-heading">Game Master Tables</li>
+
+            <% registration.game_masters.sort.each do |gm| %>
+              <li class="row list-group-item"><%= gm.table.session.name %>
+                : <%= link_to "#{gm.table.scenario.long_name}", gm.table.scenario %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+    </div>
   <% end %>
 </div>
 
 <hr>
 
-<% if current_user.admin? %>
-    <%= link_to 'New Event', new_event_path, :class => 'btn btn-warning' %>
-    <br>
+<% if admin? %>
+  <%= link_to 'New Event', new_event_path, :class => 'btn btn-warning' %>
+  <br>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,7 +8,7 @@
       attend.
       <br/><br/>
       This is done by clicking the <span class="btn btn-warning">Register</span> button next to the event on the events
-      listing<% unless user_signed_in? %>, once you have <%= link_to 'Logged in', new_user_session_path, :class => 'btn btn-info' %><% end %>.
+      listing<% unless user_signed_in? %>, once you have <%= link_to 'logged in', new_user_session_path, :class => 'btn btn-info' %><% end %>.
     </div>
   </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,5 @@
 <p id="notice"><%= notice %></p>
-<h1>All Events</h1>
+<h1>All Upcoming Events</h1>
 <div class="well">
   <div class="bg-warning">
     <div class="lead text-danger"><b>Important Note:</b></div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -370,7 +370,7 @@
     <div><%= button_to "Register for #{@event.name}?", new_event_user_event_path(@event), :class => 'btn btn-warning', method: :get %></div>
 <% end %>
 <hr>
-<% if current_user.admin? %>
+<% if admin? %>
     <%= button_to 'Add Session', new_event_session_path(@event), :class => 'btn btn-warning', :method => :get %>
     <%= button_to 'Edit', edit_event_path(@event), :class => 'btn btn-primary', :method => :get %>
 <% end %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -34,7 +34,7 @@
       <% end %>
   <% end %>
 
-  <% if user_signed_in? && admin? %>
+  <% if  admin? %>
       <li><u>Event Admin</u></li>
       <li><%= link_to 'Events', events_path %></li>
       <% if @event and @event.persisted? %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -34,7 +34,7 @@
       <% end %>
   <% end %>
 
-  <% if user_signed_in? && current_user.admin? %>
+  <% if user_signed_in? && admin? %>
       <li><u>Event Admin</u></li>
       <li><%= link_to 'Events', events_path %></li>
       <% if @event and @event.persisted? %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -73,7 +73,7 @@
     <% end %>
   </li>
   <li>
-    <% if current_user.nil? %>
+    <% unless user_signed_in? %>
         <a href="mailto:<%= ENV['GMAIL_SMTP_USERNAME'] %>">Contact Us!</a>
     <% else %>
         <%= link_to('Contact Us!', contact_path) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
     <% if user_signed_in? %>
         <div>
           Logged in as: <%= current_user.name %> (<%= current_user.email %>)
-          <% if current_user.admin? %>[ADMIN]
+          <% if admin? %>[ADMIN]
           <% end %>
           <% unless current_user.forum_username.nil? %>{<%= current_user.forum_username %>}
           <% end %>

--- a/app/views/layouts/table-assignment.html.erb
+++ b/app/views/layouts/table-assignment.html.erb
@@ -37,7 +37,7 @@
     <% if user_signed_in? %>
         <div>
           Logged in as: <%= current_user.name %> (<%= current_user.email %>)
-          <% if current_user.admin? %>[ADMIN]
+          <% if admin? %>[ADMIN]
           <% end %>
           <% unless current_user.forum_username.nil? %>{<%= current_user.forum_username %>}
           <% end %>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -57,7 +57,7 @@
         </td>
         <td nowrap="nowrap">
           <%= link_to 'Show', scenario, :class => 'btn btn-info' %>
-          <% if current_user.admin? %>
+          <% if admin? %>
               <%= link_to 'Edit', edit_scenario_path(scenario), :class => 'btn btn-primary' %>
               <%= link_to 'Destroy', scenario, method: :delete, data: {confirm: 'Are you sure?'}, :class => 'btn btn-danger' %>
           <% end %>

--- a/app/views/user_events/_form.html.erb
+++ b/app/views/user_events/_form.html.erb
@@ -12,7 +12,7 @@
     <% end %>
 
 
-    <% if current_user.admin? %>
+    <% if admin? %>
         <%# admin section %>
         <div>
           <%= f.label :user_id %>:

--- a/app/views/user_events/new.html.erb
+++ b/app/views/user_events/new.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @event.name %></h1>
 
-<% if current_user.admin? %>
+<% if admin? %>
     <h2>Admin register user for an event:</h2>
     <p>Note: currently there will be no notification sent to the user. (<em>This is a planned future enhancement.</em>)
       <br> Also, make sure that you are registering the correct user for the correct event!</p>

--- a/app/views/user_events/show.html.erb
+++ b/app/views/user_events/show.html.erb
@@ -104,7 +104,7 @@
 <% end %>
 
 
-<% if current_user.admin? %>
+<% if admin? %>
     <%= link_to 'Back to Registrations', event_user_events_path(@event), :class => 'btn btn-success' %>
     <%= link_to 'Edit', edit_event_user_event_path(@event, @user_event), :class => 'btn btn-primary' %>
 <% end %>


### PR DESCRIPTION
The primary goal of this patch is to allow folks access to the event listings (and welcome page) without having to be authenticated. This evidently caused some trouble in the past. 

This makes sure that all calls for `admin?` are through the helper instead of through `current_user`.

Most pages still require full authentication at this time... we can look at opening up more pages in the future. 
