### PR TITLE
Add ability for GMs to self-register for tables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ railsbox-passwords.txt
 /development.sh
 /config/app_environment_variables.rb
 /test/html_reports/
+/sample_GM_email.pdf

--- a/app/controllers/game_masters_controller.rb
+++ b/app/controllers/game_masters_controller.rb
@@ -19,12 +19,6 @@ class GameMastersController < ApplicationController
   # GET /game_masters/new
   def new
     @game_master = GameMaster.new
-    # @user_event
-    # current_user.user_events.each do |gm|
-    #   if gm.event == @event
-    #     @user_event = gm
-    #   end
-    # end
   end
 
   def get_possible_gms
@@ -87,7 +81,6 @@ class GameMastersController < ApplicationController
   def create
     # TODO - do something if already registered for table/session
     @game_master = GameMaster.new(game_master_params)
-    user         = nil
     if current_user.admin?
       @user_event = @game_master.user_event
       puts @user_event

--- a/app/controllers/registration_tables_controller.rb
+++ b/app/controllers/registration_tables_controller.rb
@@ -80,7 +80,6 @@ class RegistrationTablesController < ApplicationController
   def create
     @registration_table = RegistrationTable.new(registration_table_params)
     respond_to do |format|
-      # this needs to be tweaked for admin users.
       if @registration_table.save
         if @registration_table.payment_ok?
           format.html {redirect_to [@event], notice: 'Table was successfully added.'}

--- a/app/controllers/registration_tables_controller.rb
+++ b/app/controllers/registration_tables_controller.rb
@@ -82,6 +82,7 @@ class RegistrationTablesController < ApplicationController
   def create
     @registration_table = RegistrationTable.new(registration_table_params)
     respond_to do |format|
+      # this needs to be tweaked for admin users.
       if @registration_table.save
         if @registration_table.payment_ok?
           format.html {redirect_to [@event], notice: 'Table was successfully added.'}
@@ -94,20 +95,6 @@ class RegistrationTablesController < ApplicationController
       end
     end
   end
-
-  # def create
-  #   respond_to do |format|
-  #     if @registration_table.save
-  #       if @registration_table.payment_ok?
-  #         format.html {redirect_to [@event], notice: 'Table was successfully added.'}
-  #       else
-  #         format.html {redirect_to new_registration_table_table_payment_path(@registration_table), notice: PREMIUM_MESSAGE}
-  #       end
-  #     else
-  #       format.html {render :new}
-  #     end
-  #   end
-  # end
 
   # PATCH/PUT /registration_tables/1
   # PATCH/PUT /registration_tables/1.json

--- a/app/controllers/registration_tables_controller.rb
+++ b/app/controllers/registration_tables_controller.rb
@@ -44,8 +44,6 @@ class RegistrationTablesController < ApplicationController
       else
         @possible_players.push user_event
       end
-      # need to sort the gms
-      # @tables = @session.tables.sort {|a,b| a <=> b}
       @possible_players = @possible_players.sort {|a, b| a <=> b}
     end
   end

--- a/app/controllers/tables_controller.rb
+++ b/app/controllers/tables_controller.rb
@@ -107,6 +107,6 @@ class TablesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def table_params
-    params.require(:table).permit(:session_id, :scenario_id, :max_players, :gms_needed, :raffle, :core, :disabled, :location, :premium, :prereg_price, :onsite_price, :non_pfs, :information)
+    params.require(:table).permit(:session_id, :scenario_id, :max_players, :gms_needed, :gm_self_select, :raffle, :core, :disabled, :location, :premium, :prereg_price, :onsite_price, :non_pfs, :information)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,25 +27,4 @@ module ApplicationHelper
     end
     unpaid_payments
   end
-
-  def sorted_user_tables (user_event)
-    # sort the sessions by start time.
-    @sessions       = user_event.event.sessions
-    @table_sessions = {}
-
-    @sessions.each do |session|
-      @table_sessions[session] = nil
-    end
-
-    user_event.registration_tables.each do |reg_table|
-      session                  = reg_table.table.session
-      @table_sessions[session] = reg_table
-    end
-    user_event.game_masters.each do |game_master|
-      session                  = game_master.table.session
-      @table_sessions[session] = game_master
-    end
-  end
-
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,24 @@ module ApplicationHelper
     unpaid_payments
   end
 
+  def sorted_user_tables (user_event)
+    # sort the sessions by start time.
+    @sessions       = user_event.event.sessions
+    @table_sessions = {}
+
+    @sessions.each do |session|
+      @table_sessions[session] = nil
+    end
+
+    user_event.registration_tables.each do |reg_table|
+      session                  = reg_table.table.session
+      @table_sessions[session] = reg_table
+    end
+    user_event.game_masters.each do |game_master|
+      session                  = game_master.table.session
+      @table_sessions[session] = game_master
+    end
+  end
+
+
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -34,4 +34,12 @@ class ContactMailer < ApplicationMailer
     mail(subject: @message.subject, to: email)
   end
 
+  def game_master(message, email, event, game_master)
+    @message = message
+    @event = event
+    @game_master = game_master
+    # add cc for registration
+    mail(subject: @message.subject, to: email)
+  end
+
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -34,12 +34,13 @@ class ContactMailer < ApplicationMailer
     mail(subject: @message.subject, to: email)
   end
 
-  def game_master(message, email, event, game_master)
+  def game_master(message, email, event, game_master, adding)
+    @adding = adding
     @message = message
     @event = event
     @game_master = game_master
     # add cc for registration
-    mail(subject: @message.subject, to: email)
+    mail(subject: @message.subject, to: email, bcc:  ENV["GMAIL_SMTP_USERNAME"])
   end
 
 end

--- a/app/models/game_master.rb
+++ b/app/models/game_master.rb
@@ -18,9 +18,4 @@ class GameMaster < ActiveRecord::Base
     end
     sorted
   end
-
-  def self_register
-    # check the table for this.
-  end
-
 end

--- a/app/models/game_master.rb
+++ b/app/models/game_master.rb
@@ -6,7 +6,7 @@ class GameMaster < ActiveRecord::Base
   validate :check_gm_count
 
   def check_gm_count
-    errors.add :game_masters, "Max GMs Exceeded" if table.game_masters.count > table.gms_needed
+    errors.add :game_masters, "Max GMs Exceeded" if table.game_masters.count >= table.gms_needed
   end
 
   def <=> (other)
@@ -17,6 +17,10 @@ class GameMaster < ActiveRecord::Base
       sorted = self.table.scenario <=> other.table.scenario
     end
     sorted
+  end
+
+  def self_register
+    # check the table for this.
   end
 
 end

--- a/app/models/registration_table.rb
+++ b/app/models/registration_table.rb
@@ -9,7 +9,7 @@ class RegistrationTable < ActiveRecord::Base
   validate :check_player_count
 
   def check_player_count
-    errors.add :registration_tables, "Max Players Exceeded" if table.registration_tables.count > table.max_players
+    errors.add :registration_tables, "Max Players Exceeded" if table.registration_tables.count >= table.max_players
   end
 
   def payment_ok?

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -50,6 +50,10 @@ class Table < ActiveRecord::Base
     self.registration_tables.length
   end
 
+  def need_gms?
+    gms_short > 0
+  end
+
   def gms_short
     self.gms_needed - current_gms
   end

--- a/app/views/contact_mailer/game_master.html.erb
+++ b/app/views/contact_mailer/game_master.html.erb
@@ -20,10 +20,13 @@
 <body>
 
 <div class="container-fluid">
-  <h1 class="alert-success">Confirmation of Table GM Assignment</h1>
+  <h1 class="alert-success">Confirmation of Table GM Assignment Change</h1>
   <h2><%= @game_master.user_event.user.formal_name %>,</h2>
-  Thank you for volunteering to be the GM for: <%= @game_master.table.long_name %> at <%= @event.name %>!
-
+  <% if @adding %>
+    Thank you for volunteering to be the GM for: <%= @game_master.table.long_name %> at <%= @event.name %>!
+  <% else %>
+    You are no longer assigned to GM:  <%= @game_master.table.long_name %> at <%= @event.name %>.
+  <% end %>
   <hr>
 
   <h2 class="alert-primary">Your schedule at <%= @event.name %></h2>
@@ -91,9 +94,11 @@
     </table>
   </div>
 
-  <div class="alert-warning">If you need to drop a table that you have volunteered to GM, you will need to reply to this email,
-    requesting to be removed. We apologize if this causes any proplems, but it is to make sure as many tables have their GMs
-     as possible.
+  <div class="alert-warning">If you need to drop a table that you have volunteered to GM, you will need to reply to this
+    email,
+    requesting to be removed. We apologize if this causes any proplems, but it is to make sure as many tables have their
+    GMs
+    as possible.
   </div>
 
 

--- a/app/views/contact_mailer/game_master.html.erb
+++ b/app/views/contact_mailer/game_master.html.erb
@@ -94,11 +94,9 @@
     </table>
   </div>
 
-  <div class="alert-warning">If you need to drop a table that you have volunteered to GM, you will need to reply to this
-    email,
-    requesting to be removed. We apologize if this causes any proplems, but it is to make sure as many tables have their
-    GMs
-    as possible.
+  <div class="alert-warning">If you need to drop a table that you have volunteered to GM, please reply to this email
+    requesting to be removed. Convention organizers will attempt to find a replacement for you. We apologize for any
+    inconvenience this may cause.
   </div>
 
 

--- a/app/views/contact_mailer/game_master.html.erb
+++ b/app/views/contact_mailer/game_master.html.erb
@@ -1,0 +1,148 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
+        integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
+
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+          integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+          crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+          integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+          crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"
+          integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T"
+          crossorigin="anonymous"></script>
+</head>
+<body>
+
+<div class="container-fluid">
+  <h1 class="alert-success">Confirmation of Table GM Assignment</h1>
+  <h2><%= @game_master.user_event.user.formal_name %>,</h2>
+  Thank you for volunteering to be the GM for: <%= @game_master.table.long_name %> at <%= @event.name %>!
+
+  <hr>
+
+  <h2 class="alert-primary">Your schedule at <%= @event.name %></h2>
+
+  <%
+    @sessions = @event.sessions
+    @table_sessions = {}
+
+    @sessions.each do |session|
+      @table_sessions[session] = nil
+    end
+
+    user_event = @game_master.user_event
+
+    user_event.registration_tables.each do |reg_table|
+      session                  = reg_table.table.session
+      @table_sessions[session] = reg_table
+    end
+    user_event.game_masters.each do |game_master|
+      session                  = game_master.table.session
+      @table_sessions[session] = game_master
+    end
+  %>
+  <div class="well">
+    <table class="table table-striped">
+      <thead>
+      <tr>
+        <th scope="col">Session</th>
+        <th scope="col">Time</th>
+        <th scope="col">Scenario</th>
+        <th scope="col">Location</th>
+        <th scope="col">Signup Type</th>
+        <th scope="col">Payment Due?</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @sessions.each do |session| %>
+        <% selection = @table_sessions[session] %>
+        <tr>
+          <td><%= session.name %></td>
+          <td><%= session.timeslot %></td>
+          <% if selection.nil? %>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          <% else %>
+            <td><%= selection.table.scenario.long_name %></td>
+            <td><%= selection.table.location %></td>
+            <% if selection.is_a? RegistrationTable %>
+              <td>Player</td>
+              <td>
+                <% unless selection.payment_ok? %>
+                  <%= number_to_currency(selection.table.price) %>
+                <% end %>
+              </td>
+            <% elsif selection.is_a? GameMaster %>
+              <td>GM</td>
+              <td></td>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="alert-warning">If you need to drop a table that you have volunteered to GM, you will need to reply to this email,
+    requesting to be removed. We apologize if this causes any proplems, but it is to make sure as many tables have their GMs
+     as possible.
+  </div>
+
+
+  <hr>
+
+  <h2>Volunteer Information</h2>
+  <ul>
+    <li>If you have volunteered before, much of what is presented below will not be new to you, but please read through
+      it anyway as some things have changed. If this is your first time, these guidelines will help answer your
+      questions and direct you through this important part of Paizo Organized Play.
+    </li>
+    <li>As a volunteer, you are the eyes, ears, face, and voice of Paizo. We expect each of you to maintain a positive
+      attitude, professional behavior, and good hygiene.
+    </li>
+    <li>The Player Boon token rolls remain the same. 10% chance per token turned in, 5 tokens max per roll. Winners roll
+      randomly on which boon received. GM boons can be claimed when turning in your first session reporting sheet.
+    </li>
+  </ul>
+  <hr>
+
+
+  <h2>Logistics:</h2>
+  <ul>
+    <li>Each GM is responsible to provide their own maps, miniatures, handouts, and PC pre-gen characters, if your
+      scenario requires them (i.e. Serpent's Ire).
+    </li>
+    <li>If for any reason, your assigned table does not run, please report to HQ for additional duty assignments.</li>
+    <li>GM’s are also responsible for having a reliable copy of the scenario they are running – power outlets are scarce
+      in the room so have another backup option if your tablet runs out of power.
+    </li>
+    <li>Chronicles and Session reporting sheets are provided.</li>
+    <li>The HQ has a supply of New Player Packets and pre-generated characters (note: if the scenario has unique
+      pregens,
+      then you will need to provide these)
+    </li>
+    <li>No personal items may be left in the HQ area.</li>
+    <li>The convention room will be closed to all players 30 minutes prior to the the running of interactive specials
+      for
+      the GM pre-special meeting. All GM’s running the specials are expected to be at this meeting, and should report at
+      least 30 minutes prior to the session start time. Please be on time, as we will be discussing signaling and the
+      like.
+    </li>
+  </ul>
+  <hr>
+
+  <p>Thank you for making <%= @event.name %> a success!</p>
+
+  <hr>
+  <p><%= @event.name %>, Minnesota Paizo Organized Play, and 10,000 Lakes Gaming</p>
+</div>
+</body>
+</html>

--- a/app/views/contact_mailer/game_master.html.erb
+++ b/app/views/contact_mailer/game_master.html.erb
@@ -104,9 +104,10 @@
 
   <h2>Volunteer Information</h2>
   <ul>
-    <li>If you have volunteered before, much of what is presented below will not be new to you, but please read through
-      it anyway as some things have changed. If this is your first time, these guidelines will help answer your
-      questions and direct you through this important part of Paizo Organized Play.
+    <li>Even if you have volunteered previously, please read through this section thourghly as instructions may have
+      changed some from previous conventions. it anyway as some things have changed. If this is your first time
+      volunteering, these guidelines will help answer your questions and guide you through this important part of Paizo
+      Organized Play.
     </li>
     <li>As a volunteer, you are the eyes, ears, face, and voice of Paizo. We expect each of you to maintain a positive
       attitude, professional behavior, and good hygiene.
@@ -120,24 +121,23 @@
 
   <h2>Logistics:</h2>
   <ul>
-    <li>Each GM is responsible to provide their own maps, miniatures, handouts, and PC pre-gen characters, if your
-      scenario requires them (i.e. Serpent's Ire).
+    <li>Each GM is responsible to provide their own maps, miniatures, handouts, and scenario-specific pre-generated
+      characters (if your scenario requires them such as in Serpent's Ire).
     </li>
-    <li>If for any reason, your assigned table does not run, please report to HQ for additional duty assignments.</li>
-    <li>GM’s are also responsible for having a reliable copy of the scenario they are running – power outlets are scarce
-      in the room so have another backup option if your tablet runs out of power.
+    <li>Each GM is responsible for having a reliable copy of the scenario they are running. Power outlets are scarce
+      in the room so GMs must have a backup option in case their computer or tablet runs out of power.
+      For safety reasons, we cannot allow extension cords to be run across the room.
     </li>
-    <li>Chronicles and Session reporting sheets are provided.</li>
-    <li>The HQ has a supply of New Player Packets and pre-generated characters (note: if the scenario has unique
-      pregens,
-      then you will need to provide these)
+    <li>Chronicles and session reporting sheets will be provided.</li>
+    <li>The HQ has a supply of New Player Packets and pre-generated iconic characters (this does not include scenario-specific
+      pre-generated characters, such as in Serpent's Ire).
     </li>
+    <li>Do not leave your assigned table until HQ has released or reassigned you. HQ may assign you to additional tasks.</li>
     <li>No personal items may be left in the HQ area.</li>
     <li>The convention room will be closed to all players 30 minutes prior to the the running of interactive specials
-      for
-      the GM pre-special meeting. All GM’s running the specials are expected to be at this meeting, and should report at
-      least 30 minutes prior to the session start time. Please be on time, as we will be discussing signaling and the
-      like.
+      for the GM pre-special meeting. All GM’s running the specials are expected to be at this meeting, and should
+      report at least 30 minutes prior to the session start time. Please be on time, as we will be discussing signaling
+      and the like.
     </li>
   </ul>
   <hr>

--- a/app/views/event_receipt/_event_tables.html.erb
+++ b/app/views/event_receipt/_event_tables.html.erb
@@ -1,0 +1,21 @@
+<% unless user_event.registration_tables.empty? %>
+  <h3>Player Sessions</h3>
+  <div class="well">
+    <ul>
+      <% user_event.registration_tables.each do |reg_table| %>
+        <li><%= "#{reg_table.table.session.name}: #{reg_table.table.scenario.long_name} at #{reg_table.table.location}" %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% unless user_event.game_masters.empty? %>
+  <h3>GM Sessions</h3>
+  <div class="well">
+    <ul>
+      <% user_event.game_masters.each do |reg_table| %>
+        <li><%= "#{reg_table.table.session.name}: #{reg_table.table.scenario.long_name} at #{reg_table.table.location}" %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/event_receipt/_registration_receipt.html.erb
+++ b/app/views/event_receipt/_registration_receipt.html.erb
@@ -36,25 +36,5 @@
   <% end %>
   <hr>
 
-  <% unless user_event.registration_tables.empty? %>
-      <h3>Player Sessions</h3>
-      <div class="well">
-        <ul>
-          <% user_event.registration_tables.each do |reg_table| %>
-              <li><%= "#{reg_table.table.session.name}: #{reg_table.table.scenario.long_name} at #{reg_table.table.location}" %></li>
-          <% end %>
-        </ul>
-      </div>
-  <% end %>
-
-  <% unless user_event.game_masters.empty? %>
-      <h3>GM Sessions</h3>
-      <div class="well">
-        <ul>
-          <% user_event.game_masters.each do |reg_table| %>
-              <li><%= "#{reg_table.table.session.name}: #{reg_table.table.scenario.long_name} at #{reg_table.table.location}" %></li>
-          <% end %>
-        </ul>
-      </div>
-  <% end %>
+  <%= render 'event_tables' %>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -92,11 +92,11 @@
       <div class="row">
         <div class="col-md-12">
           <div class="bg-warning text-danger">
-            Registering for this event here does NOT register you for the
-            convention. To do that, you will need to register at the URL below. You will not be able to play or GM
+            Registering for this event here does NOT register you for the convention.
+            To do that, you will need to register at the URL below. You will not be able to play or GM
             without a paid registration to the convention itself!
           </div>
-          <div class="bg-warning text-info">However, registration for individual tables is handled here.</div>
+          <div class="bg-warning text-info">Sign-up for individual tables is handled here.</div>
         </div>
       </div>
       <div class="row">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,6 @@
-<p id="notice"><%= notice %></p>
+<% unless notice.nil? %>
+  <p id="notice" class="alert alert-success"><%= notice %></p>
+<% end %>
 
 <style type="text/css">
   dt, dd {
@@ -16,8 +18,8 @@
     <dd class=" text-info"><%= @event.start.localtime.to_formatted_s(:long) %>
       to <%= @event.end.localtime.to_formatted_s(:long) %></dd>
     <% if @event.event_number? %>
-        <dt>Event Number:</dt>
-        <dd class=" text-info"><%= @event.event_number %></dd>
+      <dt>Event Number:</dt>
+      <dd class=" text-info"><%= @event.event_number %></dd>
     <% end %>
   </dl>
 </div>
@@ -25,19 +27,19 @@
 <div>
   <h2>Online Registration</h2>
   <% if @event.closed? %>
-      <div class="alert-danger lead">Online Registration is closed!</div>
+    <div class="alert-danger lead">Online Registration is closed!</div>
   <% else %>
-      <% if @event.early_bird? %>
-          <% unless @event.prereg_closed? %>
-              <div class="text-warning">
-                <span class="lead">Early Bird/Pre-registration closes: <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %></span>
-              </div>
-          <% end %>
+    <% if @event.early_bird? %>
+      <% unless @event.prereg_closed? %>
+        <div class="text-warning">
+          <span class="lead">Early Bird/Pre-registration closes: <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %></span>
+        </div>
       <% end %>
-      <% unless @event.rsvp_close.nil? %>
-          <div class="lead text-warning">Registration
-            closes: <%= @event.rsvp_close.localtime.to_formatted_s(:long_ordinal) %></div>
-      <% end %>
+    <% end %>
+    <% unless @event.rsvp_close.nil? %>
+      <div class="lead text-warning">Registration
+        closes: <%= @event.rsvp_close.localtime.to_formatted_s(:long_ordinal) %></div>
+    <% end %>
   <% end %>
 </div>
 
@@ -49,29 +51,29 @@
   </div>
   <div class="well">
     <% if @event.charity? %>
-        <div class="row">
-          <div class="col-md-4 text-info">
-            <strong>This is a charity event.</strong>
-          </div>
+      <div class="row">
+        <div class="col-md-4 text-info">
+          <strong>This is a charity event.</strong>
         </div>
+      </div>
     <% end %>
     <% if !@event.price.nil? && @event.price > 0 %>
-        <div class="row">
-          <div class="col-md-2">
-            <strong>Cost:</strong>
-          </div>
-          <div class="col-md-6">
-            <% unless @event.prereg_closed? %>
-                <%= number_to_currency(@event.prereg_price) %>
-                <% unless @event.prereg_ends.nil? %>
-                    (after <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %> it will
-                    be <%= number_to_currency @event.onsite_price %>)
-                <% end %>
-            <% else %>
-                <%= number_to_currency @event.onsite_price %>
-            <% end %>
-          </div>
+      <div class="row">
+        <div class="col-md-2">
+          <strong>Cost:</strong>
         </div>
+        <div class="col-md-6">
+          <% unless @event.prereg_closed? %>
+            <%= number_to_currency(@event.prereg_price) %>
+            <% unless @event.prereg_ends.nil? %>
+              (after <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %> it will
+              be <%= number_to_currency @event.onsite_price %>)
+            <% end %>
+          <% else %>
+            <%= number_to_currency @event.onsite_price %>
+          <% end %>
+        </div>
+      </div>
     <% end %>
 
     <div class="row">
@@ -80,54 +82,54 @@
       </div>
       <div class="col-md-2">
         <% if @registration %>
-            Yes
+          Yes
         <% else %>
-            No
+          No
         <% end %>
       </div>
     </div>
     <% if !@event.external_url.blank? %>
-        <div class="row">
-          <div class="col-md-12">
-            <div class="bg-warning text-danger">
-              Registering for this event here does NOT register you for the
-              convention. To do that, you will need to register at the URL below. You will not be able to play or GM
-              without a paid registration to the convention itself!
-            </div>
-            <div class="bg-warning text-info">However, registration for individual tables is handled here.</div>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="bg-warning text-danger">
+            Registering for this event here does NOT register you for the
+            convention. To do that, you will need to register at the URL below. You will not be able to play or GM
+            without a paid registration to the convention itself!
           </div>
+          <div class="bg-warning text-info">However, registration for individual tables is handled here.</div>
         </div>
-        <div class="row">
-          <div class="col-md-2">
-            <strong>Register for convention at:</strong>
-          </div>
+      </div>
+      <div class="row">
+        <div class="col-md-2">
+          <strong>Register for convention at:</strong>
+        </div>
 
-          <div class="col-md-4">
-            <a target="_blank" href="<%= @event.external_url %>"><%= @event.external_url %></a>
-          </div>
+        <div class="col-md-4">
+          <a target="_blank" href="<%= @event.external_url %>"><%= @event.external_url %></a>
         </div>
+      </div>
     <% end %>
 
     <% if @registration && @registration.event.price&.nonzero? %>
-        <div class="row">
-          <div class="col-md-2"><b>Paid?</b></div>
-          <% if @registration.payment_ok? %>
-              <div class="col-md-6">
-                Yes (<%= number_to_currency (@registration.payment_amount.to_f / 100) %>
-                <% if @registration.payment_date %>
-                    on <%= @registration.payment_date.localtime.to_formatted_s(:long_ordinal) %>
-                <% end %>)
-              </div>
-          <% else %>
-              <div class="col-md-2">
-                <% # This has to be dynamic for future events. %>
-                No:
-              </div>
-              <div class="col-md-6">
-                <%= render partial: "registration_payment/registration_payment", locals: {event: @event, user_event: @registration} %>
-              </div>
-          <% end %>
-        </div>
+      <div class="row">
+        <div class="col-md-2"><b>Paid?</b></div>
+        <% if @registration.payment_ok? %>
+          <div class="col-md-6">
+            Yes (<%= number_to_currency (@registration.payment_amount.to_f / 100) %>
+            <% if @registration.payment_date %>
+              on <%= @registration.payment_date.localtime.to_formatted_s(:long_ordinal) %>
+            <% end %>)
+          </div>
+        <% else %>
+          <div class="col-md-2">
+            <% # This has to be dynamic for future events. %>
+            No:
+          </div>
+          <div class="col-md-6">
+            <%= render partial: "registration_payment/registration_payment", locals: {event: @event, user_event: @registration} %>
+          </div>
+        <% end %>
+      </div>
     <% end %>
 
   </div>
@@ -138,15 +140,17 @@
 
   <div class="well">
     <% unless @event.gm_volunteer_link.blank? %>
-        <div class="bg-info" style="margin-top: 1em;padding: 1em;">If you would like to GM for <%= @event.name %>
-          please do so at our:
-          <input type="button" class="btn btn-primary" value="GM Volunteer Form" formtarget="_blank"
-                 onclick="window.open('<%= @event.gm_volunteer_link %>',  '_blank');">
-        </div>
+      <div class="bg-info" style="margin-top: 1em;padding: 1em;">If you would like to GM for <%= @event.name %>
+        please do so at our:
+        <input type="button" class="btn btn-primary" value="GM Volunteer Form" formtarget="_blank"
+               onclick="window.open('<%= @event.gm_volunteer_link %>',  '_blank');">
+      </div>
     <% end %>
     <div class="bg-warning text-warning" style="margin-top: 0">
-      <div style="display: inline-block; vertical-align: top; font-size: 1.5em;"><span class="text-danger glyphicon glyphicon-warning-sign"></span></div>
-      <div style="display: inline-block;">If you are planning on GMing in a slot, please do not sign up to play in that slot.
+      <div style="display: inline-block; vertical-align: top; font-size: 1.5em;">
+        <span class="text-danger glyphicon glyphicon-warning-sign"></span></div>
+      <div style="display: inline-block;">If you are planning on GMing in a slot, please do not sign up to play in that
+        slot.
         <br>The hosts of <%= @event.name %> will assign you to your GM slot once you have registered and paid
         for <%= @event.name %>.
       </div>
@@ -158,14 +162,14 @@
   <h3>Sessions/Scenarios Offered</h3>
 
   <% if @event.closed? %>
-      <div class="well">
-        <div class="bg-warning text-danger lead" style="margin-bottom: 0">
-          <strong>Online registration is closed</strong>
-        </div>
-        <div class="bg-warning text-primary" style="margin-top: 0">In order to make any changes to your
-          registrations and signups, you will need to see HQ at the event.
-        </div>
+    <div class="well">
+      <div class="bg-warning text-danger lead" style="margin-bottom: 0">
+        <strong>Online registration is closed</strong>
       </div>
+      <div class="bg-warning text-primary" style="margin-top: 0">In order to make any changes to your
+        registrations and signups, you will need to see HQ at the event.
+      </div>
+    </div>
   <% end %>
 
   <% sessionList = @event.sessions.sort {|a, b| a.start <=> b.start} %>
@@ -189,189 +193,193 @@
   </div>
 
   <% sessionList.each do |session| %>
-      <div class="row no-pad striped-outer">
-        <div class="col-md-4 no-pad">
-          <div class="row no-pad">
-            <div class="col-md-6 no-pad">
-              <%= link_to "#{session.name}", [@event, session] %>
-            </div>
-            <div class="col-md-6 no-pad">
-              <%= session.start.strftime("%a %H:%M") %> - <%= session.end.strftime("%a %H:%M") %>
-            </div>
+    <div class="row no-pad striped-outer">
+      <div class="col-md-4 no-pad">
+        <div class="row no-pad">
+          <div class="col-md-6 no-pad">
+            <%= link_to "#{session.name}", [@event, session] %>
+          </div>
+          <div class="col-md-6 no-pad">
+            <%= session.start.strftime("%a %H:%M") %> - <%= session.end.strftime("%a %H:%M") %>
           </div>
         </div>
-        <div class="col-md-8 no-pad">
-          <!-- scenarios here -->
-          <% session.tables.sort {|a, b| a <=> b}.each do |table| %>
-              <div class="row no-pad striped-inner">
-                <div class="col-md-5 no-pad ">
-                  <%# TODO make this a reusable partial %>
-                  <% scenario = table.scenario %>
-                  <%= scenario.long_name %>
-                  <% if table.premium? && !table.game_masters[0].nil? %>
-                      with <%= table.game_masters[0].user_event.user.formal_name %>
-                  <% end %>
-                  <%= render 'table_badges', table: table %></div>
+      </div>
+      <div class="col-md-8 no-pad">
+        <!-- scenarios here -->
+        <% session.tables.sort {|a, b| a <=> b}.each do |table| %>
+          <div class="row no-pad striped-inner">
+            <div class="col-md-5 no-pad ">
+              <%# TODO make this a reusable partial %>
+              <% scenario = table.scenario %>
+              <%= scenario.long_name %>
+              <% if table.premium? && !table.game_masters[0].nil? %>
+                with <%= table.game_masters[0].user_event.user.formal_name %>
+              <% end %>
+              <%= render 'table_badges', table: table %></div>
 
-                <%# TODO Make this a partial or helper %>
-                <div class="col-md-1 no-pad">
-                  <button data-toggle="modal" title="<%= scenario.long_name %>" data-target="#scenario_<%= scenario.id %>" class="btn btn-xs btn-info">Details</button>
-                  <div id="scenario_<%= scenario.id %>" class="modal fade" role="dialog">
-                    <div class="modal-dialog">
-                      <div class="modal-content">
-                        <div class="modal-header">
-                          <button type="button" class="close" data-dismiss="modal">&times;</button>
-                          <h4 class="modal-header"><%= scenario.long_name %></h4>
+            <%# TODO Make this a partial or helper %>
+            <div class="col-md-1 no-pad">
+              <button data-toggle="modal" title="<%= scenario.long_name %>" data-target="#scenario_<%= scenario.id %>" class="btn btn-xs btn-info">Details</button>
+              <div id="scenario_<%= scenario.id %>" class="modal fade" role="dialog">
+                <div class="modal-dialog">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <button type="button" class="close" data-dismiss="modal">&times;</button>
+                      <h4 class="modal-header"><%= scenario.long_name %></h4>
+                    </div>
+                    <div class="modal-body">
+                      <div>
+                        <b>Type:</b>  <%= scenario.type_of %>
+                      </div>
+                      <% if scenario.pregen_only %>
+                        <div class="bg-primary">
+                          This scenario is pregen-only.
                         </div>
-                        <div class="modal-body">
-                          <div>
-                            <b>Type:</b>  <%= scenario.type_of %>
-                          </div>
-                          <% if scenario.pregen_only %>
-                              <div class="bg-primary">
-                                This scenario is pregen-only.
-                              </div>
-                          <% end %>
-                          <% if scenario.hard_mode %>
-                              <div class="bg-primary">
-                                This scenario has a hard mode.
-                              </div>
-                          <% end %>
-                          <hr>
-                          <div style="white-space: pre-wrap;"><%= scenario.description %></div>
-                          <div>
-                            <strong>Written by:</strong> <%= scenario.author %>
-                          </div>
-                          <div>
-                            <% unless table.scenario.paizo_url.nil? %>
-                                <a href="<%= scenario.paizo_url %>" target="_blank">Click to see on Paizo's
-                                  site</a>.
-                            <% end %>
-                          </div>
-                          <div class="modal-footer">
-                            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                          </div>
+                      <% end %>
+                      <% if scenario.hard_mode %>
+                        <div class="bg-primary">
+                          This scenario has a hard mode.
                         </div>
+                      <% end %>
+                      <hr>
+                      <div style="white-space: pre-wrap;"><%= scenario.description %></div>
+                      <div>
+                        <strong>Written by:</strong> <%= scenario.author %>
+                      </div>
+                      <div>
+                        <% unless table.scenario.paizo_url.nil? %>
+                          <a href="<%= scenario.paizo_url %>" target="_blank">Click to see on Paizo's
+                            site</a>.
+                        <% end %>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                       </div>
                     </div>
                   </div>
                 </div>
-                <% registrations_available = (table.max_players > table.registration_tables.length) %>
-                <div class="col-md-2 no-pad " style="padding-left: 0.25em;">
-                  <% if !registrations_available %>
-                      <span class="text-danger"><b>Full</b></span>
+              </div>
+            </div>
+            <% registrations_available = (table.max_players > table.registration_tables.length) %>
+            <div class="col-md-2 no-pad " style="padding-left: 0.25em;">
+              <% if !registrations_available %>
+                <span class="text-danger"><b>Full</b></span>
+              <% else %>
+                <%= table.max_players - table.registration_tables.length %> of <%= table.max_players %>
+                left
+              <% end %>
+
+            </div>
+            <% if @registration %>
+              <div class="col-md-3 no-pad " style="padding-left: 1em;">
+                <% if @tables.include? table %>
+                  <% registration_table = @reg_tables_hash[table] %>
+                  <% if registration_table.payment_ok? %>
+                    <span class="badge badge-player">Player</span>
                   <% else %>
-                      <%= table.max_players - table.registration_tables.length %> of <%= table.max_players %>
-                      left
+                    <%= render partial: "table_payment/table_payment", locals: {event: @event, registration_table: registration_table, button_label: "Pay for Ticket"} %>
+                  <% end %>
+                <% elsif @gm_tables.include? table %>
+                  <span class="badge badge-gm">GM</span>
+                <% else %>
+                  <!-- No -->
+                <% end %>
+
+                <% if @tables.include? table %>
+                  <!-- get table for this user -->
+                  <% table.registration_tables.each do |reg_table| %>
+                    <% unless @event.closed? %>
+                      <% if @reg_tables.include?(reg_table) %>
+                        <% unless reg_table.table.premium %>
+                          <%= button_to 'Remove', [@event, session, table, reg_table], method: :delete, data: {confirm: "Are you sure you want to remove your RSVP for #{reg_table.table.long_name}?"}, :class => 'btn btn-xs btn-danger', method: :delete %>
+                        <% else %>
+                          <%= button_to 'Remove', [@event, session, table, reg_table], method: :delete, data: {confirm: "Are you sure you want to remove your RSVP for #{reg_table.table.long_name}? Canceling your RSVP will not refund your money."}, :class => 'btn btn-xs btn-danger', method: :delete %>
+                        <% end %>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+
+                <% registered_this_session = @sessions.include?(session) || @gm_sessions.include?(session) %>
+                <% if !registered_this_session && registrations_available && @registration.payment_ok? %>
+                  <% unless table.raffle? or @event.closed? %>
+                    <% unless table.premium? %>
+                      <%= button_to 'Sign Up', new_event_session_table_registration_table_path(@event, session, table),
+                                    :class => "btn btn-xs btn-primary", :method => :get, :disabled => table.disabled? %>
+                    <% else %>
+                      <%= button_to "Buy Ticket for #{number_to_currency table.price}", new_event_session_table_registration_table_path(@event, session, table),
+                                    :class => "btn btn-xs btn-success", :method => :get, :disabled => table.disabled?,
+                                    data:  {confirm: "This is a premium event with a price of #{number_to_currency table.price}. You will have 1 hour to pay for this ticket."}
+                      %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+
+                <% if !registered_this_session && table.gm_self_select? && table.need_gms? %>
+                  <%= button_to 'I will GM!', new_event_session_table_game_master_path(@event, session, table),
+                                :class => "btn btn-xs btn-primary", :method => :get, :disabled => table.disabled? %>
                   <% end %>
 
-                </div>
-                <% if @registration %>
-                    <div class="col-md-3 no-pad " style="padding-left: 1em;">
-                      <% if @tables.include? table %>
-                          <% registration_table = @reg_tables_hash[table] %>
-                          <% if registration_table.payment_ok? %>
-                              <span class="badge badge-player">Player</span>
-                          <% else %>
-                              <%= render partial: "table_payment/table_payment", locals: {event: @event, registration_table: registration_table, button_label: "Pay for Ticket"} %>
-                          <% end %>
-                      <% elsif @gm_tables.include? table %>
-                          <span class="badge badge-gm">GM</span>
-                      <% else %>
-                          <!-- No -->
-                      <% end %>
 
-                      <% if @tables.include? table %>
-                          <!-- get table for this user -->
-                          <% table.registration_tables.each do |reg_table| %>
-                              <% unless @event.closed? %>
-                                  <% if @reg_tables.include?(reg_table) %>
-                                      <% unless reg_table.table.premium %>
-                                          <%= button_to 'Remove', [@event, session, table, reg_table], method: :delete, data: {confirm: "Are you sure you want to remove your RSVP for #{reg_table.table.long_name}?"}, :class => 'btn btn-xs btn-danger', method: :delete %>
-                                      <% else %>
-                                          <%= button_to 'Remove', [@event, session, table, reg_table], method: :delete, data: {confirm: "Are you sure you want to remove your RSVP for #{reg_table.table.long_name}? Canceling your RSVP will not refund your money."}, :class => 'btn btn-xs btn-danger', method: :delete %>
-                                      <% end %>
-                                  <% end %>
-                              <% end %>
-                          <% end %>
-                      <% end %>
+                  </div>
 
-                      <% registered_this_session = @sessions.include?(session) || @gm_sessions.include?(session) %>
-                      <% if !registered_this_session && registrations_available && @registration.payment_ok? %>
-                          <% unless table.raffle? or @event.closed? %>
-                              <% unless table.premium? %>
-                                  <%= button_to 'Sign Up', new_event_session_table_registration_table_path(@event, session, table),
-                                                :class => "btn btn-xs btn-primary", :method => :get, :disabled => table.disabled?%>
-                              <% else %>
-                                  <%= button_to "Buy Ticket for #{number_to_currency table.price}", new_event_session_table_registration_table_path(@event, session, table),
-                                                :class => "btn btn-xs btn-success", :method => :get, :disabled => table.disabled?,
-                                                data:  {confirm: "This is a premium event with a price of #{number_to_currency table.price}. You will have 1 hour to pay for this ticket."}
-                                  %>
-                              <% end %>
-
-                          <% end %>
-
-                      <% end %>
-
-
-                    </div>
                 <% else %>
                     <div class="col-md-3 no-pad">&nbsp;</div>
                 <% end %>
                 <!-- end of is registered -->
                 <div class="col-md-1 no-pad ">
                   <% if table.game_masters.nil? %>
-                      <%= table.gms_needed %>
+                    <%= table.gms_needed %>
                   <% else %>
-                      <%= table.gms_needed - table.game_masters.size %>
+                    <%= table.gms_needed - table.game_masters.size %>
                   <% end %> of <%= table.gms_needed %>
                 </div>
-              </div> <%# end of the scenario list %>
+                </div> <%# end of the scenario list %>
 
-          <% end %>
-          <%# this should be a different shading for the totals %>
-          <div class="row no-pad totals">
-            <div class="col-md-1 col-md-offset-5"><span class="text-primary"><strong>Totals:</strong></span>
-            </div>
-            <div class="col-md-2 no-pad ">
+            <% end %>
+            <%# this should be a different shading for the totals %>
+            <div class="row no-pad totals">
+              <div class="col-md-1 col-md-offset-5"><span class="text-primary"><strong>Totals:</strong></span>
+              </div>
+              <div class="col-md-2 no-pad ">
               <span class="text-primary"><%= session.total_max_players - session.players_count %>
                 of <%= session.total_max_players %> left</span></div>
-            <div class="col-md-3 no-pad ">&nbsp;</div>
+              <div class="col-md-3 no-pad ">&nbsp;</div>
 
-            <% if session.gm_count == session.total_gms_needed %>
+              <% if session.gm_count == session.total_gms_needed %>
                 <% klass = 'text-primary' %>
-            <% else %>
+              <% else %>
                 <% klass = 'text-danger' %>
-            <% end %>
-            <div class="col-md-1 no-pad"><span class="<%= klass %>"><%= session.total_gms_needed - session.gm_count %>
-              of <%= session.total_gms_needed %> needed</span>
+              <% end %>
+              <div class="col-md-1 no-pad"><span class="<%= klass %>"><%= session.total_gms_needed - session.gm_count %>
+                of <%= session.total_gms_needed %> needed</span>
+              </div>
             </div>
-          </div>
+            </div>
+            </div>
+        <% end %>
         </div>
-      </div>
-  <% end %>
-</div>
 
 
-<hr>
-<% if @registration %>
-    <div>
-      <%= link_to raw("<span class='glyphicon glyphicon-warning-sign' aria-hidden='true'></span> Unregister for #{@registration.event.name}"),
-                  [@event, @registration],
-                  method: :delete,
-                  data:   {confirm: 'Are you sure? Unregistering for the event will remove you from all tables, and will not refund your payment.'},
-                  :class  => 'btn btn-danger' %>
+        <hr>
+        <% if @registration %>
+          <div>
+            <%= link_to raw("<span class='glyphicon glyphicon-warning-sign' aria-hidden='true'></span> Unregister for #{@registration.event.name}"),
+                        [@event, @registration],
+                        method: :delete,
+                        data:   {confirm: 'Are you sure? Unregistering for the event will remove you from all tables, and will not refund your payment.'},
+                        :class  => 'btn btn-danger' %>
 
-      <% if @registration && @registration.paid? %>
-          <em>Note: unregistering will not refund your payment(s).</em>
-      <% end %>
-    </div>
-<% else %>
-    <div><%= button_to "Register for #{@event.name}?", new_event_user_event_path(@event), :class => 'btn btn-warning', method: :get %></div>
-<% end %>
-<hr>
-<% if admin? %>
-    <%= button_to 'Add Session', new_event_session_path(@event), :class => 'btn btn-warning', :method => :get %>
-    <%= button_to 'Edit', edit_event_path(@event), :class => 'btn btn-primary', :method => :get %>
-<% end %>
-<%= button_to 'Back', events_path, :class => 'btn btn-success', :method => :get %>
+            <% if @registration && @registration.paid? %>
+              <em>Note: unregistering will not refund your payment(s).</em>
+            <% end %>
+          </div>
+        <% else %>
+          <div><%= button_to "Register for #{@event.name}?", new_event_user_event_path(@event), :class => 'btn btn-warning', method: :get %></div>
+        <% end %>
+        <hr>
+        <% if admin? %>
+          <%= button_to 'Add Session', new_event_session_path(@event), :class => 'btn btn-warning', :method => :get %>
+          <%= button_to 'Edit', edit_event_path(@event), :class => 'btn btn-primary', :method => :get %>
+        <% end %>
+        <%= button_to 'Back', events_path, :class => 'btn btn-success', :method => :get %>

--- a/app/views/game_masters/_form.html.erb
+++ b/app/views/game_masters/_form.html.erb
@@ -1,18 +1,21 @@
 <%= form_for([@event, @session, @table, @game_master]) do |f| %>
-    <% if @game_master.errors.any? %>
-        <div id="error_explanation">
-          <h2><%= pluralize(@game_master.errors.count, "error") %> prohibited this game_master from being saved:</h2>
+  <% if @game_master.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@game_master.errors.count, "error") %> prohibited this game_master from being saved:</h2>
 
-          <ul>
-            <% @game_master.errors.full_messages.each do |message| %>
-                <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-    <% end %>
+      <ul>
+        <% @game_master.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 
-    <%= f.hidden_field :table_id, :value => @table.id %>
-    <%# this needs to be a dropdown of registered users -- which can be found from the user_events %>
+
+
+  <%= f.hidden_field :table_id, :value => @table.id %>
+  <%# this needs to be a dropdown of registered users -- which can be found from the user_events %>
+  <% if admin? %>
     <div class="field">
       <%= f.label :user_event_id, "Game Master" %>
       <% if @game_master.user_event
@@ -21,17 +24,17 @@
            gm_id = 0
          end %>
       <%# have to make user_event_id required. %>
-      <%= f.select :user_event_id, options_for_select(@possible_gms.map { |user_event| [user_event.user.name, user_event.id] }.to_h, gm_id), include_blank: 'Select User...' %>
+      <%= f.select :user_event_id, options_for_select(@possible_gms.map {|user_event| [user_event.user.name, user_event.id]}.to_h, gm_id), include_blank: 'Select User...' %>
     </div>
-    <hr>
-    <!--
-    <% @not_available.each do |user_event| %>
-        <div><%= user_event.user.name %></div>
-    <% end %>
-    -->
 
     <hr>
     <div class="actions">
       <%= f.submit "Add GM to Table", :class => 'btn btn-warning' %>
     </div>
+  <% else %>
+
+    <div class="actions">
+      <%= f.submit "Add me as GM to Table", :class => 'btn btn-warning' %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/game_masters/new.html.erb
+++ b/app/views/game_masters/new.html.erb
@@ -5,9 +5,20 @@
   </h2>
   <h3><%= @table.long_name %></h3>
 </div>
-<h4>Add GM to Table</h4>
+
+
+<div class="well">
+  <div class="field">
+    Description: <%= @table.scenario.description %>
+  </div>
+  <% if @table.scenario.author.present? %>
+    <div>by <%= @table.scenario.author %></div>
+  <% end %>
+  <%= render partial: 'events/table_badges', locals: {table: @table} %>
+</div>
 <%= render 'form' %>
 
+<% if admin? %>
 <h4>Current Players in session.</h4>
 <div class="well">
   <button data-toggle="collapse" data-target="#players" class="btn btn-info">Show</button>
@@ -70,5 +81,6 @@
     <% end %>
   </div>
 </div>
+<% end %>
 
 <%= link_to 'Back', event_session_table_game_masters_path, :class => 'btn btn-success' %>

--- a/app/views/game_masters/new.html.erb
+++ b/app/views/game_masters/new.html.erb
@@ -18,6 +18,11 @@
 </div>
 <%= render 'form' %>
 
+<div class="alert-info">Once you have volunteered to GM a table, you will need to contact the hosts of the event (either
+  by replying to your confirmation email, or through <a href="email:<%= ENV['GMAIL_SMTP_USERNAME'] %>?Subject=I%20can%20no%20longer%20GM%20something">our contact email</a>
+
+</div>
+
 <% if admin? %>
 <h4>Current Players in session.</h4>
 <div class="well">

--- a/app/views/scenarios/_form.html.erb
+++ b/app/views/scenarios/_form.html.erb
@@ -13,12 +13,12 @@
 
     <div class="field">
       <%= f.label :game_system %><br>
-      <%= f.select :game_system, %w(PFS SFS Other) %>
+      <%= f.select :game_system, %w(PFS SFS Playtest PFS2 ACG Other) %>
     </div>
 
     <div class="field">
       <%= f.label :type_of %><br>
-      <%= f.select :type_of, ['Scenario', 'Quest', 'Module', 'Adventure Path', 'ACG'] %>
+      <%= f.select :type_of, ['Scenario', 'Quest', 'Module', 'Adventure Path', 'ACG', 'Other'] %>
     </div>
     <div class="field">
       <%= f.label :season %><br>

--- a/app/views/tables/_form.html.erb
+++ b/app/views/tables/_form.html.erb
@@ -91,7 +91,7 @@
 
     <tr>
       <td>
-        <%= f.label :gms_needed, 'How many GMs are needed for this table' %>
+        <%= f.label :gms_needed, 'How many GMs are needed for this table?' %>
         <div><em>(suggested 1 GM per 6 players)</em></div>
       </td>
       <td><%= f.number_field :gms_needed %></td>

--- a/app/views/tables/_form.html.erb
+++ b/app/views/tables/_form.html.erb
@@ -1,98 +1,109 @@
 <%= form_for([@event, @session, @table]) do |f| %>
-    <% if @table.errors.any? %>
-        <div id="error_explanation">
-          <h2><%= pluralize(@table.errors.count, "error") %> prohibited this table from being saved:</h2>
+  <% if @table.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@table.errors.count, "error") %> prohibited this table from being saved:</h2>
 
-          <ul>
-            <% @table.errors.full_messages.each do |message| %>
-                <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-    <% end %>
-
-    <table class="table formTable">
-      <tr>
-        <td>
-          <%= f.label :scenario_id %>
-        </td>
-        <td>
-          <%# add default row %>
-          <%= f.select :scenario_id, options_for_select(@scenarios.map {|scenario| [scenario.season.to_s + "-" +scenario.scenario_number.to_s.rjust(2, "0") + ": " + scenario.name, scenario.id]}, @table.scenario_id), {include_blank: true} %>
-        </td>
-      </tr>
-      <tr>
-        <td><%= f.label :location %></td>
-        <td><%= f.text_field :location %></td>
-      </tr>
-
-      <tr>
-        <td><%= f.label :disabled, 'Disable RSVPs' %></td>
-        <td><%= f.check_box :disabled %></td>
-      </tr>
-
-      <tr>
-        <td><%= f.label :non_pfs, 'This table is not for Society credit' %></td>
-        <td><%= f.check_box :non_pfs %></td>
-      </tr>
-
-      <tr>
-        <td>
-          <%= f.label :raffle, 'The table is for a raffle?' %>
-        </td>
-        <td>
-          <%= f.check_box :raffle %>
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          <%= f.label :premium, 'Is this a premium table?' %>
-          <div class="text-info">Premium tables are for fee only, at time of registration.</div>
-        </td>
-        <td>
-          <%= f.check_box :premium %>
-        </td>
-      </tr>
-      <!-- put a conditional here for javascript -->
-      <tr>
-        <td>
-          <%= f.label :prereg_price, 'What is the Early Bird or Prereg price for joining this table?' %>
-          <div>This will be used before <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %></div>
-        </td>
-        <td><%= f.number_field :prereg_price %> </td>
-      </tr>
-
-      <tr>
-        <td>
-          <%= f.label :onsite_price, 'What is the Regular or Onsite price for joining this table?' %>
-          <div>This will be used after <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %></div>
-        </td>
-        <td><%= f.number_field :onsite_price %> </td>
-      </tr>
-
-      <tr>
-        <td><%= f.label :core, 'CORE table' %></td>
-        <td><%= f.check_box :core %></td>
-      </tr>
-
-      <tr>
-        <td><%= f.label :information, 'Additional information for players (character requirements, etc).' %></td>
-        <td><%= f.text_area :information %>
-      </tr>
-
-      <tr>
-        <td><%= f.label :max_players %></td>
-        <td><%= f.number_field :max_players %></td>
-      </tr>
-
-      <tr>
-        <td><%= f.label :gms_needed %></td>
-        <td><%= f.number_field :gms_needed %></td>
-      </tr>
-    </table>
-
-    <div class="actions">
-      <%= f.submit 'Save Changes', :class => 'btn btn-primary' %>
+      <ul>
+        <% @table.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
     </div>
+  <% end %>
+
+  <table class="table formTable">
+    <tr>
+      <td>
+        <%= f.label :scenario_id %>
+      </td>
+      <td>
+        <%# add default row %>
+        <%= f.select :scenario_id, options_for_select(@scenarios.map {|scenario| [scenario.season.to_s + "-" + scenario.scenario_number.to_s.rjust(2, "0") + ": " + scenario.name, scenario.id]}, @table.scenario_id), {include_blank: true} %>
+      </td>
+    </tr>
+    <tr>
+      <td><%= f.label :location %></td>
+      <td><%= f.text_field :location %></td>
+    </tr>
+
+    <tr>
+      <td><%= f.label :disabled, 'Disable RSVPs' %></td>
+      <td><%= f.check_box :disabled %></td>
+    </tr>
+
+    <tr>
+      <td><%= f.label :non_pfs, 'This table is not for Society credit' %></td>
+      <td><%= f.check_box :non_pfs %></td>
+    </tr>
+
+    <tr>
+      <td>
+        <%= f.label :raffle, 'The table is for a raffle?' %>
+      </td>
+      <td>
+        <%= f.check_box :raffle %>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        <%= f.label :premium, 'Is this a premium table?' %>
+        <div class="text-info">Premium tables are for fee only, at time of registration.</div>
+      </td>
+      <td>
+        <%= f.check_box :premium %>
+      </td>
+    </tr>
+    <!-- put a conditional here for javascript -->
+    <tr>
+      <td>
+        <%= f.label :prereg_price, 'What is the Early Bird or Prereg price for joining this table?' %>
+        <div>This will be used before <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %></div>
+      </td>
+      <td><%= f.number_field :prereg_price %> </td>
+    </tr>
+
+    <tr>
+      <td>
+        <%= f.label :onsite_price, 'What is the Regular or Onsite price for joining this table?' %>
+        <div>This will be used after <%= @event.prereg_ends.localtime.to_formatted_s(:long_ordinal) %></div>
+      </td>
+      <td><%= f.number_field :onsite_price %> </td>
+    </tr>
+
+    <tr>
+      <td><%= f.label :core, 'CORE table' %></td>
+      <td><%= f.check_box :core %></td>
+    </tr>
+
+    <tr>
+      <td><%= f.label :information, 'Additional information for players (character requirements, etc).' %></td>
+      <td><%= f.text_area :information %>
+    </tr>
+
+    <tr>
+      <td>
+        <%= f.label :max_players, 'What is the maximum number of players?' %>
+        <div><em>(Typically 6 per physical table)</em></div>
+      </td>
+      <td><%= f.number_field :max_players %></td>
+    </tr>
+
+    <tr>
+      <td>
+        <%= f.label :gms_needed, 'How many GMs are needed for this table' %>
+        <div><em>(suggested 1 GM per 6 players)</em></div>
+      </td>
+      <td><%= f.number_field :gms_needed %></td>
+    </tr>
+
+    <tr>
+      <td><%= f.label :gm_self_select, 'Can GMs select this table for themselves?' %></td>
+      <td><%= f.check_box :gm_self_select %></td>
+    </tr>
+  </table>
+
+  <div class="actions">
+    <%= f.submit 'Save Changes', :class => 'btn btn-primary' %>
+  </div>
 <% end %>

--- a/app/views/tables/show.html.erb
+++ b/app/views/tables/show.html.erb
@@ -6,14 +6,14 @@
   </h2>
   <h3><%= @table.long_name %></h3>
   <% unless @table.location.nil? %>
-      <h4>Table Location(s): <%= @table.location %></h4>
+    <h4>Table Location(s): <%= @table.location %></h4>
   <% end %>
 </div>
 
 <div class="well">
   <div style="white-space: pre-wrap"><%= @scenario.description %></div>
   <% if @scenario.author.present? %>
-      <div>by <%= @scenario.author %></div>
+    <div>by <%= @scenario.author %></div>
   <% end %>
   <%= render partial: 'events/table_badges', locals: {table: @table} %>
 </div>
@@ -26,9 +26,9 @@
   </p>
   <button data-toggle="collapse" data-target="#players" class="btn btn-info">Current Players</button>
   <% if admin? %>
-      <% if @table.registration_tables.size < @table.max_players %>
-          <%= button_to "Add Player", new_event_session_table_registration_table_path(@event, @session, @table), method: :get, :class => "btn btn-warning" %>
-      <% end %>
+    <% if @table.registration_tables.size < @table.max_players %>
+      <%= button_to "Add Player", new_event_session_table_registration_table_path(@event, @session, @table), method: :get, :class => "btn btn-warning" %>
+    <% end %>
   <% end %>
   <div id="players" class="collapse">
     <%#  header row %>
@@ -37,33 +37,40 @@
       <div class="col-md-3 label label-default">Email</div>
       <div class="col-md-2 label label-default">PFS Number</div>
       <% if admin? %>
-          <div class="col-md-2 label label-default">Admin</div>
+        <div class="col-md-2 label label-default">Admin</div>
       <% end %>
     </div>
     <% @table.registration_tables.each do |reg_table| %>
-        <% player = reg_table.user_event.user %>
-        <div class="row">
-          <div class="col-md-2"><%= player.name %></div>
-          <div class="col-md-3"><%= player.email %></div>
-          <div class="col-md-2"><%= player.pfs_number %></div>
-          <% if admin? %>
-              <div class="col-md-2"><%= button_to 'Remove from Table', [@event, @session, @table, reg_table], method: :delete, data: {confirm: "Are you sure you want to remove #{player.long_name} from #{@scenario.long_name}?"}, :class => "btn btn-danger" %></div>
-          <% end %>
-        </div>
+      <% player = reg_table.user_event.user %>
+      <div class="row">
+        <div class="col-md-2"><%= player.name %></div>
+        <div class="col-md-3"><%= player.email %></div>
+        <div class="col-md-2"><%= player.pfs_number %></div>
+        <% if admin? %>
+          <div class="col-md-2"><%= button_to 'Remove from Table', [@event, @session, @table, reg_table], method: :delete, data: {confirm: "Are you sure you want to remove #{player.long_name} from #{@scenario.long_name}?"}, :class => "btn btn-danger" %></div>
+        <% end %>
+      </div>
     <% end %>
   </div>
 </div>
 <h4>GM Information</h4>
 <div class="well">
+
+  <% if @table.gm_self_select? %>
+    <p>GMs can sign up for themselves!</p>
+  <% else %>
+    <p>A host must assign GMs.</p>
+  <% end %>
+
   <p>This table current has <span class="badge"><%= @table.game_masters.size %></span> out of
     <span class="badge"><%= @table.gms_needed %></span> game masters.
   </p>
   <div>
     <button data-toggle="collapse" data-target="#gamemasters" class="btn btn-info">Current Game Masters</button>
     <% if admin? %>
-        <% if @table.game_masters.size < @table.gms_needed %>
-            <%= button_to "Add GM", new_event_session_table_game_master_path(@event, @session, @table), method: :get, :class => "btn btn-warning" %>
-        <% end %>
+      <% if @table.game_masters.size < @table.gms_needed %>
+        <%= button_to "Add GM", new_event_session_table_game_master_path(@event, @session, @table), method: :get, :class => "btn btn-warning" %>
+      <% end %>
     <% end %>
   </div>
   <div id="gamemasters" class="collapse">
@@ -73,29 +80,29 @@
       <div class="col-md-3 label label-default">Email</div>
       <div class="col-md-2 label label-default">PFS Number</div>
       <% if admin? %>
-          <div class="col-md-2 label label-default">Admin</div>
+        <div class="col-md-2 label label-default">Admin</div>
       <% end %>
     </div>
     <% @table.game_masters.each do |game_master| %>
-        <% gm = game_master.user_event.user %>
-        <div class="row">
-          <div class="col-md-2"><%= gm.name %></div>
-          <div class="col-md-3"><%= gm.email %></div>
-          <div class="col-md-2"><%= gm.pfs_number %></div>
-          <% if admin? %>
-              <div class="col-md-2"><%= button_to 'Remove from Table', [@event, @session, @table, game_master], method: :delete, data: {confirm: "Are you sure you want to remove #{gm.long_name} as a GM from #{@scenario.long_name}?"}, :class => "btn btn-danger" %></div>
-          <% end %>
-        </div>
+      <% gm = game_master.user_event.user %>
+      <div class="row">
+        <div class="col-md-2"><%= gm.name %></div>
+        <div class="col-md-3"><%= gm.email %></div>
+        <div class="col-md-2"><%= gm.pfs_number %></div>
+        <% if admin? %>
+          <div class="col-md-2"><%= button_to 'Remove from Table', [@event, @session, @table, game_master], method: :delete, data: {confirm: "Are you sure you want to remove #{gm.long_name} as a GM from #{@scenario.long_name}?"}, :class => "btn btn-danger" %></div>
+        <% end %>
+      </div>
     <% end %>
   </div>
 </div>
 
 <hr>
 <% if admin? %>
-    <%= button_to 'Edit this table', edit_event_session_table_path(@event, @session, @table),
-                  method: :get, :class => "btn btn-primary" %>
-    <%= button_to 'Back', event_session_tables_path, method: :get, :class => "btn btn-success" %>
+  <%= button_to 'Edit this table', edit_event_session_table_path(@event, @session, @table),
+                method: :get, :class => "btn btn-primary" %>
+  <%= button_to 'Back', event_session_tables_path, method: :get, :class => "btn btn-success" %>
 <% else %>
-    <%= button_to 'Back', event_path, method: :get, :class => "btn btn-success" %>
+  <%= button_to 'Back', event_path, method: :get, :class => "btn btn-success" %>
 <% end %>
 <hr>

--- a/db/migrate/20180628022059_add_gm_self_select_to_table.rb
+++ b/db/migrate/20180628022059_add_gm_self_select_to_table.rb
@@ -1,0 +1,5 @@
+class AddGmSelfSelectToTable < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tables, :gm_self_select, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170912192352) do
+ActiveRecord::Schema.define(version: 20180628022059) do
 
   create_table "additional_payments", force: :cascade do |t|
     t.string   "category"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20170912192352) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.index ["user_event_id"], name: "index_additional_payments_on_user_event_id"
+  end
+
+  create_table "event_hosts", force: :cascade do |t|
+    t.date     "start_date"
+    t.date     "end_date"
+    t.integer  "user_id"
+    t.integer  "event_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_event_hosts_on_event_id"
+    t.index ["user_id"], name: "index_event_hosts_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -97,18 +108,19 @@ ActiveRecord::Schema.define(version: 20170912192352) do
     t.integer  "session_id"
     t.integer  "scenario_id"
     t.integer  "max_players"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.integer  "gms_needed",   default: 1
-    t.boolean  "raffle",       default: false
-    t.boolean  "core",         default: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "gms_needed",     default: 1
+    t.boolean  "raffle",         default: false
+    t.boolean  "core",           default: false
     t.string   "location"
     t.boolean  "premium"
-    t.integer  "prereg_price", default: 0
-    t.integer  "onsite_price", default: 0
-    t.boolean  "disabled",     default: false
+    t.integer  "prereg_price",   default: 0
+    t.integer  "onsite_price",   default: 0
+    t.boolean  "disabled",       default: false
     t.boolean  "non_pfs"
     t.string   "information"
+    t.boolean  "gm_self_select", default: true
     t.index ["scenario_id"], name: "index_tables_on_scenario_id"
     t.index ["session_id"], name: "index_tables_on_session_id"
   end

--- a/test/mailers/previews/contact_mailer_preview.rb
+++ b/test/mailers/previews/contact_mailer_preview.rb
@@ -26,10 +26,25 @@ class ContactMailerPreview < ActionMailer::Preview
     ContactMailer.session_reminder(@message, @admins, @event)
   end
 
+  #   def game_master(message, email, event, game_master)
+  def game_master_preview
+    @event = Event.first
+    @user = User.first
+    user_event = @user.user_events.first
+    # byebug
+    game_master = user_event.game_masters.first
+    message = Message.new
+    message.subject = "Change in GM assignments for #{@event.name}"
+
+    email = @user.email
+
+    ContactMailer.game_master(message, email, @event, game_master)
+  end
+
   private
   def setup_user_event
     @event              = Event.new
-    @event.name         = 'SkålCon 2017'
+    @event.name         = 'SkålCon 2018'
     @event.prereg_price = 20
     @event.onsite_price = 25
     @event.prereg_ends  = 5.days.from_now
@@ -45,4 +60,5 @@ class ContactMailerPreview < ActionMailer::Preview
   def setup_admins
     @admins = User.where(admin: true)
   end
+
 end

--- a/test/mailers/previews/contact_mailer_preview.rb
+++ b/test/mailers/previews/contact_mailer_preview.rb
@@ -26,12 +26,10 @@ class ContactMailerPreview < ActionMailer::Preview
     ContactMailer.session_reminder(@message, @admins, @event)
   end
 
-  #   def game_master(message, email, event, game_master)
   def game_master_add_preview
     @event = Event.first
     @user = User.first
     user_event = @user.user_events.first
-    # byebug
     game_master = user_event.game_masters.first
     message = Message.new
     message.subject = "Change in GM assignments for #{@event.name}"
@@ -42,12 +40,10 @@ class ContactMailerPreview < ActionMailer::Preview
   end
 
 
-  #   def game_master(message, email, event, game_master)
   def game_master_delete_preview
     @event = Event.first
     @user = User.first
     user_event = @user.user_events.first
-    # byebug
     game_master = user_event.game_masters.first
     message = Message.new
     message.subject = "Change in GM assignments for #{@event.name}"

--- a/test/mailers/previews/contact_mailer_preview.rb
+++ b/test/mailers/previews/contact_mailer_preview.rb
@@ -27,7 +27,7 @@ class ContactMailerPreview < ActionMailer::Preview
   end
 
   #   def game_master(message, email, event, game_master)
-  def game_master_preview
+  def game_master_add_preview
     @event = Event.first
     @user = User.first
     user_event = @user.user_events.first
@@ -38,7 +38,23 @@ class ContactMailerPreview < ActionMailer::Preview
 
     email = @user.email
 
-    ContactMailer.game_master(message, email, @event, game_master)
+    ContactMailer.game_master(message, email, @event, game_master, true)
+  end
+
+
+  #   def game_master(message, email, event, game_master)
+  def game_master_delete_preview
+    @event = Event.first
+    @user = User.first
+    user_event = @user.user_events.first
+    # byebug
+    game_master = user_event.game_masters.first
+    message = Message.new
+    message.subject = "Change in GM assignments for #{@event.name}"
+
+    email = @user.email
+
+    ContactMailer.game_master(message, email, @event, game_master, false)
   end
 
   private


### PR DESCRIPTION
This requires that the appropriate field be selected in the table creation,
which is the default.

Sends an email to the GM and to the registration email address whenever a GM is assigned to a table

Adds boilerplate explaining how to request to be removed from
a table (which will be included in the email as well)

Also removed some commented out blocks, and (accidently) reformatted some files.