### PR TITLE
Add seat to `RegistrationTable`

### DIFF
--- a/app/controllers/registration_tables_controller.rb
+++ b/app/controllers/registration_tables_controller.rb
@@ -86,7 +86,18 @@ class RegistrationTablesController < ApplicationController
   # POST /registration_tables
   # POST /registration_tables.json
   def create
+
     @registration_table = RegistrationTable.new(registration_table_params)
+
+    # TODO - is there a better way to do this?
+    seat = RegistrationTable.where(table_id: @table.id).maximum('seat')
+    if seat.nil?
+      seat = 1
+    else
+      seat = seat + 1
+    end
+    @registration_table.seat = seat
+
     respond_to do |format|
       if @registration_table.save
         if @registration_table.payment_ok?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,10 @@ class Event < ActiveRecord::Base
     closed
   end
 
+  def date_range
+    "#{start.localtime.to_formatted_s(:long)} to #{self.end.localtime.to_formatted_s(:long)}"
+  end
+
   def premium_tables
     premium_tables = []
     sessions.each do |session|

--- a/app/views/registration_tables/show.json.jbuilder
+++ b/app/views/registration_tables/show.json.jbuilder
@@ -1,1 +1,19 @@
-json.extract! @registration_table, :id, :table, :user_event, :created_at, :updated_at
+json.event do
+  json.set! :event_name, @event.name
+  json.set! :event_date, @event.date_range
+end
+json.ticket do
+  json.set! :ticket_number, @registration_table.id
+  json.set! :session, @session.name
+  json.set! :session_start_time, @session.start.localtime.to_formatted_s(:long)
+  json.set! :table, @table.name
+  json.set! :location, @table.location
+  json.set! :seat , @registration_table.seat
+  json.set! :max, @registration_table.table.max_players
+end
+json.player do
+  user = @registration_table.user_event.user
+  json.set! :name, user.formal_name
+  json.set! :pfs_number, user.pfs_number
+  json.set! :registration, @registration_table.user_event.id
+end


### PR DESCRIPTION
This also updates the JSON for `RegistrationTable` to be more usable for ticketing
A couple of other tweaks, but nothing major
Adds a seat value to the rsvp when created.

Needs something to run through and assign seat numbers to all pre-existing rows.