### PR TITLE
Add chat server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ railsbox-passwords.txt
 /config/app_environment_variables.rb
 /test/html_reports/
 /sample_GM_email.pdf
+/coverage

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -144,7 +144,8 @@ class EventsController < ApplicationController
   def event_params
     params.require(:event).permit(:name, :start, :end, :location, :rsvp_close, :prereg_ends, :charity,
                                   :prereg_price, :onsite_price, :info, :gm_volunteer_link, :tables_reg_offsite,
-                                  :external_url, :event_number, :online_sales_end, :online, :in_person)
+                                  :external_url, :event_number, :online_sales_end, :online, :in_person, 
+                                  :chat_server, :chat_server_url)
   end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,14 +7,24 @@ class Event < ActiveRecord::Base
   has_many :registration_tables, through: :tables
 
   validate :event_type_validator
-  # validate :has_chat_server_validator
+  validate :has_chat_server_validator
 
-  # def has_chat_server_validator
-  #   errors[:chat_server].push 'must have a chat server url' if self.chat_server && !self.chat_server_url
-  # end
+  def has_chat_server_validator
+    errors[:chat_server].push 'must have both a name and a valid URL' unless self.valid_chat_server
+  end
 
-  def has_chat_server
-    
+  def valid_chat_server
+    if self.chat_server.nil?
+      if self.chat_server_url.nil?
+        return true
+      end
+    else
+      if !self.chat_server_url.nil?
+        return true
+      end
+    end
+
+    return false
   end
 
   def event_type_validator

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,15 @@ class Event < ActiveRecord::Base
   has_many :registration_tables, through: :tables
 
   validate :event_type_validator
+  # validate :has_chat_server_validator
+
+  # def has_chat_server_validator
+  #   errors[:chat_server].push 'must have a chat server url' if self.chat_server && !self.chat_server_url
+  # end
+
+  def has_chat_server
+    
+  end
 
   def event_type_validator
     errors[:online].push 'must have one of online or in person selected' unless self.event_type_selected

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -43,12 +43,23 @@
     <%= f.datetime_select :prereg_ends %>
   </div>
   <div class="field">
-    <%= f.label :online_sales_end, 'Online sale/selection of table tickets ends' %>
+    <%= f.label :online_sales_end, 'Online sale/selection of table tickets ends' %><br>
     <%= f.datetime_select :online_sales_end %>
   </div>
   <div class="field">
     <%= f.label :rsvp_close %><br>
     <%= f.datetime_select :rsvp_close %>
+  </div>
+
+  <hr/>
+
+  <div class="field">
+    <%= f.label :chat_server %><br>
+    <%= f.text_field :chat_server %>
+  </div>
+  <div class="field">
+    <%= f.label :chat_server_url %><br>
+    <%= f.text_field :chat_server_url %>
   </div>
 
   <hr/>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,8 +29,10 @@
       <% elsif @event.online? %>Online
       <% end %>
     </dd>
-    <dt>Chat Server:</dt>
-    <dd><a target="_blank" href="<%= @event.chat_server_url %>"><%= @event.chat_server %></a></dd>
+    <% if @event.has_chat_server? %>
+      <dt>Chat Server:</dt>
+      <dd><a target="_blank" href="<%= @event.chat_server_url %>"><%= @event.chat_server %></a></dd>
+    <% end %>
   </dl>
 </div>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,7 +29,8 @@
       <% elsif @event.online? %>Online
       <% end %>
     </dd>
-
+    <dt>Chat Server:</dt>
+    <dd><a target="_blank" href="<%= @event.chat_server_url %>"><%= @event.chat_server %></a></dd>
   </dl>
 </div>
 

--- a/db/migrate/20200628214833_add_chat_to_event.rb
+++ b/db/migrate/20200628214833_add_chat_to_event.rb
@@ -1,5 +1,6 @@
 class AddChatToEvent < ActiveRecord::Migration[5.2]
   def change
     add_column :events, :chat_server, :string
+    add_column :events, :chat_server_url, :string
   end
 end

--- a/db/migrate/20200628214833_add_chat_to_event.rb
+++ b/db/migrate/20200628214833_add_chat_to_event.rb
@@ -1,0 +1,5 @@
+class AddChatToEvent < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :chat_server, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_28_201503) do
+ActiveRecord::Schema.define(version: 2020_06_28_214833) do
 
   create_table "additional_payments", force: :cascade do |t|
     t.string "category"
@@ -58,6 +58,8 @@ ActiveRecord::Schema.define(version: 2020_06_28_201503) do
     t.boolean "tables_reg_offsite", default: false
     t.boolean "in_person", default: true
     t.boolean "online", default: false
+    t.string "chat_server"
+    t.string "chat_server_url"
   end
 
   create_table "game_masters", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ users = User.create!([{name:     "Jack Brown", pfs_number: 74294, admin: true, e
                        password: 'password', password_confirmation: 'password'},
                       {name:     "Keith Apperson", pfs_number: 124235, admin: true, email: "ziegrauros@gmail.com",
                        password: 'password', password_confirmation: 'password'},
-                      {name:     "Ryan Blomquist", pfs_number: 8769, admin: true, email: "blomquistr@gmail.com",
+                      {name:     "Ryan Blomquist", pfs_number: 8769, admin: true, email: "blomquist.r@gmail.com",
                        password: 'password', password_confirmation: 'password'}])
 
 userEvent = UserEvent.create!([{event_id: 1, user_id: 1}])

--- a/spec/model/event_spec.rb
+++ b/spec/model/event_spec.rb
@@ -34,5 +34,24 @@ describe Event, type: :model do
       expect(event.event_type_selected).to be false
       expect(event.errors[:online]).to_not be_empty
     end
+
+    it 'If an event has a chat server, the UI should validate that' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = 'https://www.google.com'
+
+      event.save
+      expect(event.has_chat_server).to be true
+    end
+
+    it 'If an event has a chat server, that server must have a URL' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = nil
+
+      event.save
+      expect(event.has_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
   end
 end

--- a/spec/model/event_spec.rb
+++ b/spec/model/event_spec.rb
@@ -34,23 +34,46 @@ describe Event, type: :model do
       expect(event.event_type_selected).to be false
       expect(event.errors[:online]).to_not be_empty
     end
+  end
 
-    it 'If an event has a chat server, the UI should validate that' do
+  context 'Event has a chat_server' do
+    it 'Event has no chat_server' do
+      event = Event.new
+      event.chat_server = nil
+      event.chat_server_url = nil
+      
+      event.save
+      expect(event.valid_chat_server).to be true
+      expect(event.errors[:chat_server]).to be_empty
+    end
+    it 'Event has a chat_server and a chat_server_url' do
       event = Event.new
       event.chat_server = 'Discord'
       event.chat_server_url = 'https://www.google.com'
 
       event.save
-      expect(event.has_chat_server).to be true
+      expect(event.valid_chat_server).to be true
+      expect(event.errors[:chat_server]).to be_empty
     end
 
-    it 'If an event has a chat server, that server must have a URL' do
+    ## TODO: is this actually invalid? I'm not sure that this shouldn't just not show the text box...
+    it 'If event has a chat_server_url but no chat_server' do
+      event = Event.new
+      event.chat_server = nil
+      event.chat_server_url = 'https://www.google.com'
+
+      event.save
+      expect(event.valid_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
+
+    it 'If an event has a chat_server and no chat_server_url' do
       event = Event.new
       event.chat_server = 'Discord'
       event.chat_server_url = nil
 
       event.save
-      expect(event.has_chat_server).to be false
+      expect(event.valid_chat_server).to be false
       expect(event.errors[:chat_server]).to_not be_empty
     end
   end


### PR DESCRIPTION
Adds `chat_server` and `chat_server_url` to `events`
Display `chat_server` value as a link to the `chat_server_url` on event details