### PR TITLE
Add chat server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ railsbox-passwords.txt
 /config/app_environment_variables.rb
 /test/html_reports/
 /sample_GM_email.pdf
+/coverage

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+//= link_directory ../images .png`

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -144,7 +144,8 @@ class EventsController < ApplicationController
   def event_params
     params.require(:event).permit(:name, :start, :end, :location, :rsvp_close, :prereg_ends, :charity,
                                   :prereg_price, :onsite_price, :info, :gm_volunteer_link, :tables_reg_offsite,
-                                  :external_url, :event_number, :online_sales_end, :online, :in_person)
+                                  :external_url, :event_number, :online_sales_end, :online, :in_person, 
+                                  :chat_server, :chat_server_url)
   end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,8 +19,8 @@ class Event < ActiveRecord::Base
       return true if self.chat_server_url.blank?
     end
 
-    unless self.chat_server.blank?
-      return true unless self.chat_server_url.blank?
+    if self.chat_server.present?
+      return true if self.chat_server_url.present?
     end
 
     false

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,17 +14,16 @@ class Event < ActiveRecord::Base
   end
 
   def valid_chat_server
-    if self.chat_server.nil?
-      if self.chat_server_url.nil?
-        return true
-      end
-    else
-      if !self.chat_server_url.nil?
-        return true
-      end
+    # using Rails blank? instead of nil to catch all whitespace or empty string
+    if self.chat_server.blank?
+      return true if self.chat_server_url.blank?
     end
 
-    return false
+    unless self.chat_server.blank?
+      return true unless self.chat_server_url.blank?
+    end
+
+    false
   end
 
   def event_type_validator

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,7 +41,7 @@ class Event < ActiveRecord::Base
   def closed?
     closed = false
     unless self.rsvp_close.nil?
-      now    = DateTime.now
+      now = DateTime.now
       closed = self.rsvp_close <= now
     end
     closed
@@ -54,7 +54,7 @@ class Event < ActiveRecord::Base
   def premium_tables
     premium_tables = []
     sessions.each do |session|
-      premium_tables.concat(session.tables.select {|table| table.premium})
+      premium_tables.concat(session.tables.select { |table| table.premium })
     end
     premium_tables
   end
@@ -62,7 +62,7 @@ class Event < ActiveRecord::Base
   def prereg_closed?
     closed = false
     unless self.prereg_ends.nil?
-      now    = DateTime.now
+      now = DateTime.now
       closed = self.prereg_ends <= now
     end
     closed
@@ -71,7 +71,7 @@ class Event < ActiveRecord::Base
   def online_sales_closed?
     closed = false
     unless self.online_sales_end.nil?
-      now    = DateTime.now
+      now = DateTime.now
       closed = self.online_sales_end <= now
     end
     closed

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,25 @@ class Event < ActiveRecord::Base
   has_many :registration_tables, through: :tables
 
   validate :event_type_validator
+  validate :has_chat_server_validator
+
+  def has_chat_server_validator
+    errors[:chat_server].push 'must have both a name and a valid URL' unless self.valid_chat_server
+  end
+
+  def valid_chat_server
+    if self.chat_server.nil?
+      if self.chat_server_url.nil?
+        return true
+      end
+    else
+      if !self.chat_server_url.nil?
+        return true
+      end
+    end
+
+    return false
+  end
 
   def event_type_validator
     errors[:online].push 'must have one of online or in person selected' unless self.event_type_selected

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,9 +7,9 @@ class Event < ActiveRecord::Base
   has_many :registration_tables, through: :tables
 
   validate :event_type_validator
-  validate :has_chat_server_validator
+  validate :chat_server_validator
 
-  def has_chat_server_validator
+  def chat_server_validator
     errors[:chat_server].push 'must have both a name and a valid URL' unless self.valid_chat_server
   end
 
@@ -24,6 +24,10 @@ class Event < ActiveRecord::Base
     end
 
     false
+  end
+
+  def chat_server?
+    self.chat_server.present? && self.chat_server_url.present?
   end
 
   def event_type_validator

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -43,12 +43,23 @@
     <%= f.datetime_select :prereg_ends %>
   </div>
   <div class="field">
-    <%= f.label :online_sales_end, 'Online sale/selection of table tickets ends' %>
+    <%= f.label :online_sales_end, 'Online sale/selection of table tickets ends' %><br>
     <%= f.datetime_select :online_sales_end %>
   </div>
   <div class="field">
     <%= f.label :rsvp_close %><br>
     <%= f.datetime_select :rsvp_close %>
+  </div>
+
+  <hr/>
+
+  <div class="field">
+    <%= f.label :chat_server %><br>
+    <%= f.text_field :chat_server %>
+  </div>
+  <div class="field">
+    <%= f.label :chat_server_url %><br>
+    <%= f.text_field :chat_server_url %>
   </div>
 
   <hr/>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,7 +29,10 @@
       <% elsif @event.online? %>Online
       <% end %>
     </dd>
-
+    <% if @event.has_chat_server? %>
+      <dt>Chat Server:</dt>
+      <dd><a target="_blank" href="<%= @event.chat_server_url %>"><%= @event.chat_server %></a></dd>
+    <% end %>
   </dl>
 </div>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,7 +29,7 @@
       <% elsif @event.online? %>Online
       <% end %>
     </dd>
-    <% if @event.has_chat_server? %>
+    <% if @event.chat_server? %>
       <dt>Chat Server:</dt>
       <dd><a target="_blank" href="<%= @event.chat_server_url %>"><%= @event.chat_server %></a></dd>
     <% end %>

--- a/db/migrate/20200628214833_add_chat_to_event.rb
+++ b/db/migrate/20200628214833_add_chat_to_event.rb
@@ -1,0 +1,6 @@
+class AddChatToEvent < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :chat_server, :string
+    add_column :events, :chat_server_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_28_201503) do
+ActiveRecord::Schema.define(version: 2020_06_28_214833) do
 
   create_table "additional_payments", force: :cascade do |t|
     t.string "category"
@@ -58,6 +58,8 @@ ActiveRecord::Schema.define(version: 2020_06_28_201503) do
     t.boolean "tables_reg_offsite", default: false
     t.boolean "in_person", default: true
     t.boolean "online", default: false
+    t.string "chat_server"
+    t.string "chat_server_url"
   end
 
   create_table "game_masters", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,49 +1,49 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
-event = Event.create!({name:       'Initial Con!', start: '2018-06-10 12:00', end: '2018-06-12 17:00',
-                       rsvp_close: '2018-6-10 18:00', prereg_ends: '2018-06-09 17:00', location: 'Fantasy Realms'})
 
-sessions = Session.create!([{event_id: event.id, name: "FRI12-17", start: '2018-06-10 12:00', end: '2018-06-10 17:00'},
-                            {event_id: event.id, name: "FRI18-23", start: '2018-06-10 18:00', end: '2018-06-10 23:00'},
-                            {event_id: event.id, name: "SAT12-17", start: '2018-06-11 12:00', end: '2018-06-11 17:00'}])
+event_start = DateTime.now.change({ hour: 12, min: 0, sec: 0 })
 
-scenarios = Scenario.create!([{type_of:   "Scenario", tier: '6-8', season: 7, scenario_number: 98,
-                               name:      "Serpents Ire", description: "This is the description", pregen_only: true,
-                               hard_mode: false, author: 'John Compton',
-                               paizo_url: 'http://paizo.com/products/btpy9lzy?Pathfinder-Society-Scenario-7-98-Serpents-Ire'},
-                              {type_of:   "Scenario", tier: '4-6', season: 7, scenario_number: 99,
-                               name:      "Through  Mailstrom Rift", description: "A Pathfinder Society Special designed for 6th-leve...",
-                               author:    "Linda Zayas-Palmer",
-                               paizo_url: "http://paizo.com/products/btpy9mbd?Pathfinder-Society-Scenario-799-Through-Maelstrom-Rift",
-                               hard_mode: false, created_at: "2016-05-11 02:59:05", updated_at: "2016-05-11 02:59:05", pregen_only: true}])
+event = Event.create!({ name: 'Initial Con!', start: event_start, end: event_start + 29.hours,
+                        rsvp_close: event_start - 1.day, prereg_ends: event_start - 1.week,
+                        location: 'Fantasy Realms' })
 
-tables = Table.create!([{session_id: 1, scenario_id: 1, max_players: 6, premium: true, prereg_price: 10, onsite_price: 20},
-                        {session_id: 1, scenario_id: 2, max_players: 6},
-                        {session_id: 2, scenario_id: 1, max_players: 6},
-                        {session_id: 3, scenario_id: 2, max_players: 6}])
+sessions = Session.create!([{ event_id: event.id, name: "Session 1", start: event_start,
+                              end: event_start + 5.hours },
+                            { event_id: event.id, name: "Session 2", start: event_start + 6.hours,
+                              end: event_start + 11.hours },
+                            { event_id: event.id, name: "Session 3", start: event_start + 24.hours,
+                              end: event_start + 29.hours }])
+
+scenarios = Scenario.create!([{ type_of: "Scenario", tier: '6-8', season: 7, scenario_number: 98,
+                                name: "Serpents Ire", description: "This is the description", pregen_only: true,
+                                hard_mode: false, author: 'John Compton',
+                                paizo_url: 'http://paizo.com/products/btpy9lzy?Pathfinder-Society-Scenario-7-98-Serpents-Ire' },
+                              { type_of: "Scenario", tier: '4-6', season: 7, scenario_number: 99,
+                                name: "Through  Mailstrom Rift", description: "A Pathfinder Society Special designed for 6th-leve...",
+                                author: "Linda Zayas-Palmer",
+                                paizo_url: "http://paizo.com/products/btpy9mbd?Pathfinder-Society-Scenario-799-Through-Maelstrom-Rift",
+                                hard_mode: false, created_at: "2016-05-11 02:59:05", updated_at: "2016-05-11 02:59:05", pregen_only: true }])
+
+tables = Table.create!([{ session_id: 1, scenario_id: 1, max_players: 6, premium: true, prereg_price: 10, onsite_price: 20 },
+                        { session_id: 1, scenario_id: 2, max_players: 6 },
+                        { session_id: 2, scenario_id: 1, max_players: 6 },
+                        { session_id: 3, scenario_id: 2, max_players: 6 }])
 
 
 puts("Seeding users!")
-users = User.create!([{name:     "Jack Brown", pfs_number: 74294, admin: true, email: "silbeg@gmail.com",
-                       password: 'password', password_confirmation: 'password'},
-                      {name:     "Keith Apperson", pfs_number: 124235, admin: true, email: "ziegrauros@gmail.com",
-                       password: 'password', password_confirmation: 'password'},
-                      {name:     "Ryan Blomquist", pfs_number: 8769, admin: true, email: "blomquist.r@gmail.com",
-                       password: 'password', password_confirmation: 'password'}])
+users = User.create!([{ name: "Jack Brown", pfs_number: 74294, admin: true, email: "silbeg@gmail.com",
+                        password: 'password', password_confirmation: 'password' },
+                      { name: "Keith Apperson", pfs_number: 124235, admin: true, email: "ziegrauros@gmail.com",
+                        password: 'password', password_confirmation: 'password' },
+                      { name: "Ryan Blomquist", pfs_number: 8769, admin: true, email: "blomquist.r@gmail.com",
+                        password: 'password', password_confirmation: 'password' }])
 
-userEvent = UserEvent.create!([{event_id: 1, user_id: 1}])
+userEvent = UserEvent.create!([{ event_id: 1, user_id: 1 }])
 
-registration_tables = RegistrationTable.create!([{user_event_id: 1, table_id: 1, paid: true, payment_amount: 1000, payment_id: 'PAYMENTID'},
-                                                 {user_event_id: 1, table_id: 3}])
+registration_tables = RegistrationTable.create!([{ user_event_id: 1, table_id: 1, paid: true, payment_amount: 1000, payment_id: 'PAYMENTID' },
+                                                 { user_event_id: 1, table_id: 3 }])
 
-additional_payments = AdditionalPayment.create!([{user_event_id:       1, category: 'auction', description: 'A really neat thingie!',
-                                                  charitable_donation: true, market_price: 2000, payment_price: 3000},
-                                                 {user_event_id:       1, category: 'auction', description: 'Another really neat thingie!',
-                                                  charitable_donation: true, market_price: 2000, payment_price: 3000},
-                                                 {user_event_id:       1, category: 'auction', description: 'Yes, another really neat thingie!',
-                                                  charitable_donation: true, market_price: 2000, payment_price: 3000}])
+additional_payments = AdditionalPayment.create!([{ user_event_id: 1, category: 'auction', description: 'A really neat thingie!',
+                                                   charitable_donation: true, market_price: 2000, payment_price: 3000 },
+                                                 { user_event_id: 1, category: 'auction', description: 'Another really neat thingie!',
+                                                   charitable_donation: true, market_price: 2000, payment_price: 3000 },
+                                                 { user_event_id: 1, category: 'auction', description: 'Yes, another really neat thingie!',
+                                                   charitable_donation: true, market_price: 2000, payment_price: 3000 }])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ users = User.create!([{name:     "Jack Brown", pfs_number: 74294, admin: true, e
                        password: 'password', password_confirmation: 'password'},
                       {name:     "Keith Apperson", pfs_number: 124235, admin: true, email: "ziegrauros@gmail.com",
                        password: 'password', password_confirmation: 'password'},
-                      {name:     "Ryan Blomquist", pfs_number: 8769, admin: true, email: "blomquistr@gmail.com",
+                      {name:     "Ryan Blomquist", pfs_number: 8769, admin: true, email: "blomquist.r@gmail.com",
                        password: 'password', password_confirmation: 'password'}])
 
 userEvent = UserEvent.create!([{event_id: 1, user_id: 1}])

--- a/spec/model/event_spec.rb
+++ b/spec/model/event_spec.rb
@@ -41,12 +41,12 @@ describe Event, type: :model do
       event = Event.new
       event.chat_server = nil
       event.chat_server_url = nil
-      
+
       event.save
       expect(event.valid_chat_server).to be true
       expect(event.errors[:chat_server]).to be_empty
     end
-    it 'Event has a chat_server and a chat_server_url' do
+    it 'Event has a chat_server and a chat_server_url errors should be empty' do
       event = Event.new
       event.chat_server = 'Discord'
       event.chat_server_url = 'https://www.google.com'
@@ -56,8 +56,7 @@ describe Event, type: :model do
       expect(event.errors[:chat_server]).to be_empty
     end
 
-    ## TODO: is this actually invalid? I'm not sure that this shouldn't just not show the text box...
-    it 'If event has a chat_server_url but no chat_server' do
+    it 'If event has a chat_server_url but no chat_server error should exist' do
       event = Event.new
       event.chat_server = nil
       event.chat_server_url = 'https://www.google.com'
@@ -67,10 +66,30 @@ describe Event, type: :model do
       expect(event.errors[:chat_server]).to_not be_empty
     end
 
-    it 'If an event has a chat_server and no chat_server_url' do
+    it 'If an event has a chat_server and no chat_server_url error should exist' do
       event = Event.new
       event.chat_server = 'Discord'
       event.chat_server_url = nil
+
+      event.save
+      expect(event.valid_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
+
+    it 'If an event has a chat_server and a blank chat_server_url error should exist' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = '   '
+
+      event.save
+      expect(event.valid_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
+
+    it 'If an event has a blanl chat_server and a chat_server_url error should exist' do
+      event = Event.new
+      event.chat_server = '  '
+      event.chat_server_url = 'https://my.chat.server/'
 
       event.save
       expect(event.valid_chat_server).to be false

--- a/spec/model/event_spec.rb
+++ b/spec/model/event_spec.rb
@@ -79,16 +79,36 @@ describe Event, type: :model do
     it 'If an event has a chat_server and a blank chat_server_url error should exist' do
       event = Event.new
       event.chat_server = 'Discord'
-      event.chat_server_url = '   '
+      event.chat_server_url = " \t\r\n"
+
+      event.save
+      expect(event.valid_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
+    it 'If an event has a chat_server and an empty chat_server_url error should exist' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = ''
 
       event.save
       expect(event.valid_chat_server).to be false
       expect(event.errors[:chat_server]).to_not be_empty
     end
 
-    it 'If an event has a blanl chat_server and a chat_server_url error should exist' do
+    it 'If an event has a blank chat_server and a chat_server_url error should exist' do
       event = Event.new
-      event.chat_server = '  '
+      # Note that if we do these special characters, we must use double quptes, because Ruby
+      event.chat_server = " \t\n\r"
+      event.chat_server_url = 'https://my.chat.server/'
+
+      event.save
+      expect(event.valid_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
+
+    it 'If an event has an empty chat_server and a chat_server_url error should exist' do
+      event = Event.new
+      event.chat_server = ''
       event.chat_server_url = 'https://my.chat.server/'
 
       event.save

--- a/spec/model/event_spec.rb
+++ b/spec/model/event_spec.rb
@@ -35,4 +35,46 @@ describe Event, type: :model do
       expect(event.errors[:online]).to_not be_empty
     end
   end
+
+  context 'Event has a chat_server' do
+    it 'Event has no chat_server' do
+      event = Event.new
+      event.chat_server = nil
+      event.chat_server_url = nil
+      
+      event.save
+      expect(event.valid_chat_server).to be true
+      expect(event.errors[:chat_server]).to be_empty
+    end
+    it 'Event has a chat_server and a chat_server_url' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = 'https://www.google.com'
+
+      event.save
+      expect(event.valid_chat_server).to be true
+      expect(event.errors[:chat_server]).to be_empty
+    end
+
+    ## TODO: is this actually invalid? I'm not sure that this shouldn't just not show the text box...
+    it 'If event has a chat_server_url but no chat_server' do
+      event = Event.new
+      event.chat_server = nil
+      event.chat_server_url = 'https://www.google.com'
+
+      event.save
+      expect(event.valid_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
+
+    it 'If an event has a chat_server and no chat_server_url' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = nil
+
+      event.save
+      expect(event.valid_chat_server).to be false
+      expect(event.errors[:chat_server]).to_not be_empty
+    end
+  end
 end

--- a/spec/model/event_spec.rb
+++ b/spec/model/event_spec.rb
@@ -116,4 +116,39 @@ describe Event, type: :model do
       expect(event.errors[:chat_server]).to_not be_empty
     end
   end
+
+  context '#chat_server?' do
+    it 'return true if both chat server and URL are present' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = 'https://www.google.com'
+
+      expect(event.chat_server?).to be true
+    end
+
+    it 'return false if chat server present and URL is blank' do
+      event = Event.new
+      event.chat_server = 'Discord'
+      event.chat_server_url = ' '
+
+      expect(event.chat_server?).to be false
+    end
+
+    it 'return false if chat server blank and URL is present' do
+      event = Event.new
+      event.chat_server = ' '
+      event.chat_server_url = 'https://www.google.com'
+
+      expect(event.chat_server?).to be false
+    end
+
+    it 'return false if chat server and URL are blank' do
+      event = Event.new
+      event.chat_server = ' '
+      event.chat_server_url = nil
+
+      expect(event.chat_server?).to be false
+    end
+
+  end
 end


### PR DESCRIPTION
This adds upon PR #139 by @blomquistr by refactoring  `Event#valid_chat_server` under green.

- Also adding tests with empty spaces, which also still pass.
- Plus some minor reformatting
- Added missing `event#chat_server?`
- Updated seeds to use dynamic date on seeding
- Refactor under green for clarity

----
This was done for clarity, to remove the nested conditionals and to use some more standard Rails checks (`string.blank?` and `string.present?` that someone not familiar with Rails might not know about.  In fact, I had forgotten that `string.present?`  even exists!

See: https://gist.github.com/pythonicrubyist/8114720 for details on what these all do.

Also added specs to test for whitesprace 

I find this code to be a lot cleaner to read, personally. 

Fixes #125 